### PR TITLE
Fix pie chart events on hovering

### DIFF
--- a/src/components/StatusPieChart.js
+++ b/src/components/StatusPieChart.js
@@ -75,6 +75,9 @@ const useStyles = makeStyles({
     fontSize: '15px',
     color: 'black',
     lineHeight: '15px'
+  },
+  percentageLabel: {
+    pointerEvents: 'none'
   }
 });
 
@@ -126,6 +129,7 @@ function StatusPieChart() {
             <Cell key={promise.status} fill={statusColors[promise.status]} />
           ))}
           <LabelList
+            className={classes.percentageLabel}
             dataKey="value"
             position="insideTop"
             formatter={PercentageLabelFormatter}


### PR DESCRIPTION
The issue is when you hover over a label, the chart will fire leave event since your over the label but still inside a sector of the chart. 
![](http://g.recordit.co/iFAsDh3Yg4.gif)

Fixed this by ignoring pointer events to the label.
![](http://g.recordit.co/xwVV7JZWkU.gif)