### PR TITLE
Fix filters history + indicators

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-helmet": "^5.2.1",
+    "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",
     "recharts": "^1.7.1"

--- a/src/components/propTypes.js
+++ b/src/components/propTypes.js
@@ -1,9 +1,56 @@
 import PropTypes from 'prop-types';
 
+const location = PropTypes.shape({
+  hash: PropTypes.string.isRequired,
+  key: PropTypes.string, // only in createBrowserHistory and createMemoryHistory
+  pathname: PropTypes.string.isRequired,
+  search: PropTypes.string.isRequired,
+  state: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.string
+  ]) // only in createBrowserHistory and createMemoryHistory
+});
+
+const routeShape = {
+  path: PropTypes.string,
+  exact: PropTypes.bool,
+  strict: PropTypes.bool,
+  sensitive: PropTypes.bool,
+  component: PropTypes.func
+};
+routeShape.routes = PropTypes.arrayOf(PropTypes.shape(routeShape));
+
 export default {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
-  ...PropTypes
+  ...PropTypes,
+  location,
+  history: PropTypes.shape({
+    action: PropTypes.oneOf(['PUSH', 'REPLACE', 'POP']).isRequired,
+    block: PropTypes.func.isRequired,
+    canGo: PropTypes.func, // only in createMemoryHistory
+    createHref: PropTypes.func.isRequired,
+    entries: PropTypes.arrayOf(location), // only in createMemoryHistory
+    go: PropTypes.func.isRequired,
+    goBack: PropTypes.func.isRequired,
+    goForward: PropTypes.func.isRequired,
+    index: PropTypes.number, // only in createMemoryHistory
+    length: PropTypes.number,
+    listen: PropTypes.func.isRequired,
+    location: location.isRequired,
+    push: PropTypes.func.isRequired,
+    replace: PropTypes.func.isRequired
+  }),
+  route: PropTypes.shape(routeShape),
+  mathch: PropTypes.shape({
+    isExact: PropTypes.bool,
+    params: PropTypes.object.isRequired,
+    path: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  })
 };

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -9,7 +9,7 @@ function Home() {
   return (
     <Page>
       <PromiseStatusIndicatorsSection />
-      <PromisesSection>
+      <PromisesSection disableFilterHistory>
         <Grid item xs={12} sm={6} md={4}>
           <PromiseCard
             status="stalled"

--- a/src/pages/Promises.js
+++ b/src/pages/Promises.js
@@ -10,7 +10,6 @@ function Promises({ location: { search } }) {
   return (
     <Page>
       <PromisesSection
-        showIndicator
         color="white"
         filter={{
           status: params.get('status'),

--- a/src/pages/sections/PromisesSection.js
+++ b/src/pages/sections/PromisesSection.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/styles';
+import { withRouter } from 'react-router';
 import { Grid } from '@material-ui/core';
 import Layout from '../../components/Layout';
 import Select from '../../components/Select';
@@ -84,7 +85,8 @@ const useStyles = makeStyles({
 function PromisesSection({
   children,
   filter: propsFilter,
-  showIndicator,
+  history,
+  disableFilterHistory,
   ...props
 }) {
   const classes = useStyles(props);
@@ -116,9 +118,11 @@ function PromisesSection({
       } else {
         params.delete('topic');
       }
-      window.location.replace(`/promises?${params.toString()}`);
+      if (!disableFilterHistory) {
+        history.push(`?${params.toString()}`);
+      }
     }
-  }, [filter]);
+  }, [disableFilterHistory, filter, history]);
   return (
     <div className={classes.root}>
       <Layout>
@@ -131,7 +135,7 @@ function PromisesSection({
         >
           <Grid item xs={6} sm={4}>
             <Select
-              showIndicator={filter.status !== 'all' && showIndicator}
+              showIndicator={filter.status !== 'all'}
               indicatorColor={
                 filter.status !== 'all' && statusColors[filter.status]
               }
@@ -151,7 +155,7 @@ function PromisesSection({
           </Grid>
           <Grid item xs={6} sm={4}>
             <Select
-              showIndicator={filter.term !== 'all' && showIndicator}
+              showIndicator={filter.term !== 'all'}
               value={filter.term}
               onChange={value => setFilter({ ...filter, term: value })}
               options={[
@@ -168,7 +172,7 @@ function PromisesSection({
           </Grid>
           <Grid item xs={6} sm={4}>
             <Select
-              showIndicator={filter.topic !== 'all' && showIndicator}
+              showIndicator={filter.topic !== 'all'}
               value={filter.topic}
               onChange={value => setFilter({ ...filter, topic: value })}
               options={[
@@ -193,8 +197,9 @@ function PromisesSection({
 }
 
 PromisesSection.propTypes = {
+  disableFilterHistory: propTypes.bool,
+  history: propTypes.history.isRequired,
   children: propTypes.children.isRequired,
-  showIndicator: propTypes.bool,
   filter: propTypes.shape({
     status: propTypes.string,
     term: propTypes.string,
@@ -203,7 +208,7 @@ PromisesSection.propTypes = {
 };
 
 PromisesSection.defaultProps = {
-  showIndicator: false,
+  disableFilterHistory: false,
   filter: {
     status: undefined,
     term: undefined,
@@ -211,4 +216,4 @@ PromisesSection.defaultProps = {
   }
 };
 
-export default PromisesSection;
+export default withRouter(PromisesSection);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9487,7 +9487,7 @@ react-router-dom@^5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.0.1:
+react-router@5.0.1, react-router@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.1.tgz#04ee77df1d1ab6cb8939f9f01ad5702dbadb8b0f"
   integrity sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==


### PR DESCRIPTION
- [x] Use react router to push history
- [x] Disable filter history on homepage
- [x] Show filter indicators on homepage currently not showing
- [x] Add react-router prop types

Homepage no history + working indicators:
![](http://g.recordit.co/RFMXjLCDMF.gif)

Promises page with history + working indictors:
![](http://g.recordit.co/OtKxBivPmk.gif)