### PR TITLE
[HOTFIX] Promise section filter on term + topic

### DIFF
--- a/src/pages/sections/PromisesSection.js
+++ b/src/pages/sections/PromisesSection.js
@@ -171,10 +171,8 @@ function PromisesSection({
             filterPromise =>
               (filter.status === 'all' ||
                 filterPromise.status === filter.status) &&
-              (filter.term === 'all' ||
-                (filterPromise.term === data.terms.slug) === filter.term) &&
-              (filter.topic === 'all' ||
-                (filterPromise.topic === data.topics.slug) === filter.topic)
+              (filter.term === 'all' || filterPromise.term === filter.term) &&
+              (filter.topic === 'all' || filterPromise.topic === filter.topic)
           )
           .map(promise => (
             <Grid item xs={12} sm={6} md={4}>


### PR DESCRIPTION
## Description

**Fixes**
Broken filter when filtering based on `term` and `topic. ` 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
