### PR TITLE
[Hotfix] Remove verification_status

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,6 @@ export default {
   GRAPHQL_URI: 'https://check-api.checkmedia.org/api/graphql',
   PROXY_URL: 'https://corsanywhere.devops.codeforafrica.org/',
   CHECK_PROJECT_DB_ID: 2831,
-  CHECK_PROMISE_VERIFICATION_STATUS: 'verified',
   CHECK_PROMISE_MAX_COUNT: 150,
   reports: {
     url: 'https://pesacheck.org/tagged/promise-tracker'

--- a/src/lib/fetchPromises.js
+++ b/src/lib/fetchPromises.js
@@ -65,7 +65,7 @@ export default async ({ apolloClient, limit: maxCount }) => {
     `,
     variables: {
       limit,
-      query: `{ "verification_status":["${config.CHECK_PROMISE_VERIFICATION_STATUS}"], "projects":["${config.CHECK_PROJECT_DB_ID}"] }`
+      query: `{ "projects":["${config.CHECK_PROJECT_DB_ID}"] }`
     }
   });
 


### PR DESCRIPTION
## Description

Since we're pulling directly from verified list (using the db_id) we no the verification_status check is no longer present and hence causes `fetchPromises` to return empty list

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![s](https://user-images.githubusercontent.com/1779590/77413728-db69f180-6dd0-11ea-8175-7b9e6164ee5d.png)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
