### PR TITLE
[Chore] Multiple node query 

### DIFF
--- a/src/lib/check/gql/GET_PROMISE.js
+++ b/src/lib/check/gql/GET_PROMISE.js
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
 export default gql`
-  query getPromise($id: String!) {
+  query getPromise($id: String!, $limit: Int!, $query: String!) {
     project_media(ids: $id) {
       id
       dbid
@@ -37,6 +37,51 @@ export default gql`
               updated_at
             }
             created_at
+          }
+        }
+      }
+    }
+    search(query: $query) {
+      medias(first: $limit) {
+        edges {
+          node {
+            id
+            dbid
+            title
+            description
+            status
+            archived
+            created_at
+            tags {
+              edges {
+                node {
+                  tag_text
+                }
+              }
+            }
+            tasks {
+              edges {
+                node {
+                  id
+                  dbid
+                  label
+                  first_response_value
+                }
+              }
+            }
+            log {
+              edges {
+                node {
+                  event_type
+                  object_changes_json
+                  task {
+                    label
+                    updated_at
+                  }
+                  created_at
+                }
+              }
+            }
           }
         }
       }

--- a/src/lib/check/index.js
+++ b/src/lib/check/index.js
@@ -230,7 +230,11 @@ function check({ team = undefined, promiseStatuses = {}, initialState = {} }) {
           singlePromise.tags.some((v) => p.tags.includes(v))
       );
 
-      return { ...singlePromise, dataset, relatedPromises };
+      return {
+        ...singlePromise,
+        dataset,
+        relatedPromises: relatedPromises.slice(0, 3),
+      };
     }
     return null;
   }

--- a/src/lib/check/index.js
+++ b/src/lib/check/index.js
@@ -217,10 +217,20 @@ function check({ team = undefined, promiseStatuses = {}, initialState = {} }) {
 
   async function handleSinglePromise({ data }) {
     const node = data?.project_media;
+
     if (node) {
       const dataset = await (getLinkedDataset(node) || {});
       const singlePromise = await nodeToPromise(node);
-      return { ...singlePromise, dataset };
+      const otherPromises = await Promise.all(
+        data?.search?.medias?.edges.map(({ node: n }) => nodeToPromise(n)) || []
+      );
+      const relatedPromises = otherPromises.filter(
+        (p) =>
+          p.id !== singlePromise.id &&
+          singlePromise.tags.some((v) => p.tags.includes(v))
+      );
+
+      return { ...singlePromise, dataset, relatedPromises };
     }
     return null;
   }

--- a/src/pages/promises/[...slug].js
+++ b/src/pages/promises/[...slug].js
@@ -44,7 +44,6 @@ function PromisePage({
   navigation,
   promise,
   labels,
-  relatedPromises,
   title: titleProp,
   ...props
 }) {
@@ -61,7 +60,7 @@ function PromisePage({
     >
       {promise ? <Promise promise={promise} {...labels} /> : null}
       <RelatedPromises
-        items={relatedPromises}
+        items={promise?.relatedPromises}
         title="Related Promises"
         withFilter={false}
         classes={{
@@ -91,8 +90,8 @@ PromisePage.propTypes = {
     description: PropTypes.string,
     image: PropTypes.string,
     title: PropTypes.string,
+    relatedPromises: PropTypes.arrayOf(PropTypes.shape({})),
   }),
-  relatedPromises: PropTypes.arrayOf(PropTypes.shape({})),
   title: PropTypes.string,
 };
 
@@ -102,7 +101,6 @@ PromisePage.defaultProps = {
   labels: undefined,
   navigation: undefined,
   promise: undefined,
-  relatedPromises: undefined,
   title: undefined,
 };
 
@@ -147,18 +145,9 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
 
   const promisePost = await checkApi.promise({
     id,
-  });
-
-  const otherPromises = await checkApi.promises({
     limit: 100,
     query: `{ "projects": ["2831"] }`,
   });
-
-  const relatedPromises = otherPromises.filter(
-    (p) =>
-      p.id !== promisePost.id &&
-      promisePost.tags.some((v) => p.tags.includes(v))
-  );
 
   const notFound = !promisePost;
   if (notFound) {
@@ -197,7 +186,6 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
       errorCode,
       languageAlternates,
       promise,
-      relatedPromises: relatedPromises.slice(0, 3),
     },
     revalidate: 2 * 60, // seconds
   };

--- a/src/pages/promises/[...slug].js
+++ b/src/pages/promises/[...slug].js
@@ -58,16 +58,20 @@ function PromisePage({
       title={title}
       classes={{ section: classes.section, footer: classes.footer }}
     >
-      {promise ? <Promise promise={promise} {...labels} /> : null}
-      <RelatedPromises
-        items={promise?.relatedPromises}
-        title="Related Promises"
-        withFilter={false}
-        classes={{
-          section: classes.section,
-          sectionTitle: classes.sectionTitle,
-        }}
-      />
+      {promise && (
+        <>
+          <Promise promise={promise} {...labels} />
+          <RelatedPromises
+            items={promise?.relatedPromises}
+            title="Related Promises"
+            withFilter={false}
+            classes={{
+              section: classes.section,
+              sectionTitle: classes.sectionTitle,
+            }}
+          />
+        </>
+      )}
       <Subscribe
         classes={{
           section: classes.section,


### PR DESCRIPTION
## Description

Perform a multiple data query to get a single promise and other promises to be used to filter related promises. This reduces extra calls to check API

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Desktop Screenshots

## Mobile Screenshots

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
