### PR TITLE
Fix Pick Promise Button Overlap

### DIFF
--- a/src/components/PickPromise/useStyles.js
+++ b/src/components/PickPromise/useStyles.js
@@ -33,7 +33,6 @@ const useStyles = makeStyles(({ typography, breakpoints }) => ({
   },
   inputSection: {
     backgroundColor: "#F7F7F7",
-    border: "0.06rem solid #EBEBEB",
     color: "#20202059",
     padding: typography.pxToRem(12),
     fontFamily: typography.fontFamily,
@@ -47,9 +46,10 @@ const useStyles = makeStyles(({ typography, breakpoints }) => ({
     color: "#FFFFFF",
     top: "0",
     width: "2em",
-    height: "2em",
+    height: "100%",
     right: 0,
-    zIndex: 1,
+    position: "relative",
+    border: "solid 10px #005DFD",
   },
   formControl: {
     width: "100%",


### PR DESCRIPTION
## Description

Fix blue dropdown button overlapping with input and triangle too big

Fixes [#176627521](https://www.pivotaltracker.com/story/show/176627521)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Desktop Screenshots

###  Before:
<img width="671" alt="Screenshot 2021-01-24 at 22 25 14" src="https://user-images.githubusercontent.com/12892109/105641203-ddd72500-5e93-11eb-999e-9ced33949256.png">

###  After:
<img width="857" alt="Screenshot 2021-01-24 at 22 24 54" src="https://user-images.githubusercontent.com/12892109/105641211-e596c980-5e93-11eb-8a71-ba8696301034.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
