### PR TITLE
rename index slug from pt-index to index

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -168,7 +168,7 @@ export async function getStaticProps({ locale }) {
     };
   }
   const wpApi = wp();
-  const page = await wpApi.pages({ slug: "pt-index", locale }).first;
+  const page = await wpApi.pages({ slug: "index", locale }).first;
   const { promiseStatuses } = page;
   const checkApi = check({
     promiseStatuses,


### PR DESCRIPTION
## Description

Change index slug from `pt-index` to `index`

Fixes # (N/A)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
