### PR TITLE
add act-now link

### DIFF
--- a/src/components/ActNow/index.js
+++ b/src/components/ActNow/index.js
@@ -99,6 +99,7 @@ function ActNow({ actionLabel, description, title, ...props }) {
                   root: classes.cta,
                   button: classes.ctaButton,
                 }}
+                href="/act-now"
               >
                 {actionLabel}
               </CtAButton>


### PR DESCRIPTION
## Description

Add link to `/act-now` page on the Learn More button on the landing page Act Now section. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Desktop Screenshots

![actnow](https://user-images.githubusercontent.com/12892109/111101461-04900e80-855b-11eb-8e9a-b73bfa50cfd3.gif)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
