### PR TITLE
Use Token instead of login

### DIFF
--- a/src/lib/wp/index.js
+++ b/src/lib/wp/index.js
@@ -89,6 +89,7 @@ function wp(site) {
     const data = res.ok ? res.json() : {};
     return data;
   }
+
   async function getRevisionById(type, id, revisionId, token, lang, params) {
     const fields = params?.fields ? `&_fields=${params.fields}` : "";
     const embed = params?.embed ? `&_embed=${params.embed}` : "";

--- a/src/lib/wp/index.js
+++ b/src/lib/wp/index.js
@@ -89,14 +89,14 @@ function wp(site) {
     const data = res.ok ? res.json() : {};
     return data;
   }
-  async function getRevisionById(type, id, revisionId, lang, params) {
+  async function getRevisionById(type, id, revisionId, token, lang, params) {
     const fields = params?.fields ? `&_fields=${params.fields}` : "";
     const embed = params?.embed ? `&_embed=${params.embed}` : "";
     const res = await fetch(
       `${WP_DASHBOARD_API_URL}/${type}/${id}/revisions/${revisionId}?lang=${lang}${fields}${embed}`,
       {
         headers: {
-          Authorization: `Bearer ${process.env.WP_TOKEN}`,
+          Authorization: `Bearer ${token}`,
           // 'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
@@ -229,8 +229,14 @@ function wp(site) {
     return createPageFrom(resource, options, lang);
   }
 
-  async function getPageRevisionById(id, revisionId, lang) {
-    const resource = await getRevisionById("pages", id, revisionId, lang);
+  async function getPageRevisionById(id, revisionId, token, lang) {
+    const resource = await getRevisionById(
+      "pages",
+      id,
+      revisionId,
+      token,
+      lang
+    );
     if (isEmpty(resource)) {
       return resource;
     }
@@ -249,8 +255,14 @@ function wp(site) {
     return createPageFrom(resource, options, lang);
   }
 
-  async function getPostRevisionById(id, revisionId, thumbnailId, lang) {
-    const resource = await getRevisionById("posts", id, revisionId, lang);
+  async function getPostRevisionById(id, revisionId, thumbnailId, token, lang) {
+    const resource = await getRevisionById(
+      "posts",
+      id,
+      revisionId,
+      token,
+      lang
+    );
 
     const author = await getResourceById("users", resource.author, lang);
     const thumbnail = await getResourceById("media", thumbnailId, lang);
@@ -345,12 +357,13 @@ function wp(site) {
       id,
       revisionId,
       thumbnailId,
+      token,
       locale = siteServer.defaultLocale,
     }) => ({
       get page() {
         return (async () => {
           if (id && revisionId) {
-            return getPageRevisionById(id, revisionId, thumbnailId, locale);
+            return getPageRevisionById(id, revisionId, token, locale);
           }
           return undefined;
         })();
@@ -358,7 +371,13 @@ function wp(site) {
       get post() {
         return (async () => {
           if (id && revisionId) {
-            return getPostRevisionById(id, revisionId, thumbnailId, locale);
+            return getPostRevisionById(
+              id,
+              revisionId,
+              thumbnailId,
+              token,
+              locale
+            );
           }
           return undefined;
         })();

--- a/src/lib/wp/index.js
+++ b/src/lib/wp/index.js
@@ -97,7 +97,6 @@ function wp(site) {
       {
         headers: {
           Authorization: `Bearer ${token}`,
-          // 'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     );
@@ -264,12 +263,12 @@ function wp(site) {
       lang
     );
 
-    const author = await getResourceById("users", resource.author, lang);
-    const thumbnail = await getResourceById("media", thumbnailId, lang);
-
     if (isEmpty(resource)) {
       return undefined;
     }
+
+    const author = await getResourceById("users", resource.author, lang);
+    const thumbnail = await getResourceById("media", thumbnailId, lang);
 
     const post = {
       ...resource,

--- a/src/lib/wp/index.js
+++ b/src/lib/wp/index.js
@@ -11,7 +11,6 @@ function wp(site) {
     config.WP_DASHBOARD_URL;
   const WP_DASHBOARD_API_URL = `${WP_DASHBOARD_URL}/wp-json/wp/v2`;
   const WP_DASHBOARD_ACF_API_URL = `${WP_DASHBOARD_URL}/wp-json/acf/v3`;
-  const WP_DASHBOARD_AUTH_API_URL = `${WP_DASHBOARD_URL}/wp-json/jwt-auth/v1/token`;
 
   async function getOptions(lang) {
     const res = await fetch(
@@ -62,22 +61,7 @@ function wp(site) {
     };
     return data;
   }
-  async function login(
-    credentials = {
-      username: process.env.DEFAULT_WP_USERNAME,
-      password: process.env.DEFAULT_WP_PASSWORD,
-    }
-  ) {
-    const res = await fetch(WP_DASHBOARD_AUTH_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(credentials),
-    });
-    const data = res.ok ? res.json() : {};
-    return data;
-  }
+
   async function getResourcesBySlug(type, slug, lang, params) {
     const fields = params?.fields ? `&_fields=${params.fields}` : "";
     const embed = params?.embed ? `&_embed=${params.embed}` : "";
@@ -106,14 +90,13 @@ function wp(site) {
     return data;
   }
   async function getRevisionById(type, id, revisionId, lang, params) {
-    const auth = await login();
     const fields = params?.fields ? `&_fields=${params.fields}` : "";
     const embed = params?.embed ? `&_embed=${params.embed}` : "";
     const res = await fetch(
       `${WP_DASHBOARD_API_URL}/${type}/${id}/revisions/${revisionId}?lang=${lang}${fields}${embed}`,
       {
         headers: {
-          Authorization: `Bearer ${auth.token}`,
+          Authorization: `Bearer ${process.env.WP_TOKEN}`,
           // 'Content-Type': 'application/x-www-form-urlencoded',
         },
       }

--- a/src/lib/wp/index.js
+++ b/src/lib/wp/index.js
@@ -228,7 +228,7 @@ function wp(site) {
     return createPageFrom(resource, options, lang);
   }
 
-  async function getPageRevisionById(id, revisionId, token, lang) {
+  async function getPageRevisionById(id, revisionId, thumbnailId, token, lang) {
     const resource = await getRevisionById(
       "pages",
       id,
@@ -239,6 +239,10 @@ function wp(site) {
     if (isEmpty(resource)) {
       return resource;
     }
+    const thumbnail = await getResourceById("media", thumbnailId, lang);
+
+    resource.featured_image_src = thumbnail?.source_url || null;
+
     if (resource.acf?.posts) {
       const posts = await Promise.all(
         resource.acf?.posts?.map((post) =>
@@ -362,7 +366,13 @@ function wp(site) {
       get page() {
         return (async () => {
           if (id && revisionId) {
-            return getPageRevisionById(id, revisionId, token, locale);
+            return getPageRevisionById(
+              id,
+              revisionId,
+              thumbnailId,
+              token,
+              locale
+            );
           }
           return undefined;
         })();

--- a/src/pages/about/[slug].js
+++ b/src/pages/about/[slug].js
@@ -43,7 +43,14 @@ export async function getStaticProps({
     page = pages[index] || null;
   }
   const languageAlternates = _.languageAlternates(`/about/${slug}`);
-
+  if (!page && preview) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: "/preview-error",
+      },
+    };
+  }
   return {
     notFound,
     props: { ...page, errorCode, languageAlternates, slug },

--- a/src/pages/about/[slug].js
+++ b/src/pages/about/[slug].js
@@ -34,14 +34,17 @@ export async function getStaticProps({
   const slug = slugParam.toLowerCase();
   const pages = await wp().pages({ slug: "about", locale }).children;
   const index = pages.findIndex((page) => page.slug === slug);
-  const notFound = index === -1;
-  const errorCode = notFound ? 404 : null;
+  let notFound;
   let page;
   if (preview && previewData) {
     page = await wp().revisions(previewData.query).page;
+    notFound = !page;
   } else {
     page = pages[index] || null;
+    notFound = index === -1;
   }
+  const errorCode = notFound ? 404 : null;
+
   const languageAlternates = _.languageAlternates(`/about/${slug}`);
   if (!page && preview) {
     return {

--- a/src/pages/analysis/articles/[slug].js
+++ b/src/pages/analysis/articles/[slug].js
@@ -149,6 +149,7 @@ export async function getStaticProps({
   let post;
   if (preview && previewData) {
     post = await wpApi.revisions(previewData.query).post;
+    console.log(previewData, post);
   } else {
     post =
       slug !== NO_ARTICLES_SLUG

--- a/src/pages/analysis/articles/[slug].js
+++ b/src/pages/analysis/articles/[slug].js
@@ -149,7 +149,6 @@ export async function getStaticProps({
   let post;
   if (preview && previewData) {
     post = await wpApi.revisions(previewData.query).post;
-    console.log(previewData, post);
   } else {
     post =
       slug !== NO_ARTICLES_SLUG

--- a/src/pages/analysis/articles/[slug].js
+++ b/src/pages/analysis/articles/[slug].js
@@ -157,6 +157,14 @@ export async function getStaticProps({
   }
 
   const notFound = !post;
+  if (notFound && preview) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: "/preview-error",
+      },
+    };
+  }
   if (notFound) {
     return {
       notFound,

--- a/src/pages/api/preview.js
+++ b/src/pages/api/preview.js
@@ -4,10 +4,11 @@ export default async function preview(req, res) {
     postId,
     revisionId,
     _thumbnail_id: thumbnailId,
+    token,
   } = req.query;
 
   res.setPreviewData({
-    query: { id: postId, revisionId, thumbnailId },
+    query: { id: postId, revisionId, thumbnailId, token },
   });
 
   if (postType === "pages") {

--- a/src/pages/preview-error.js
+++ b/src/pages/preview-error.js
@@ -1,0 +1,29 @@
+import React from "react";
+
+import ErrorPage from "@/promisetracker/components/ErrorPage";
+
+import i18n from "@/promisetracker/lib/i18n";
+import wp from "@/promisetracker/lib/wp";
+
+function PreviewErrorPage(props) {
+  return <ErrorPage {...props} />;
+}
+
+export async function getStaticProps({ locale }) {
+  const wpApi = wp();
+  const page = await wpApi.pages({ slug: "preview-error", locale }).first;
+  const posts = await wpApi.pages({ slug: "analysis-articles", locale }).posts;
+  const articles = posts?.slice(0, 4) || null;
+  const languageAlternates = i18n().languageAlternates("/404");
+
+  return {
+    props: {
+      ...page,
+      articles,
+      languageAlternates,
+    },
+    revalidate: 30 * 60, // seconds
+  };
+}
+
+export default PreviewErrorPage;


### PR DESCRIPTION
## Description

To shorten Vercel function request TTL, use WordPress token instead of WordPress username and password. We only have [10 seconds ](https://vercel.com/docs/platform/limits)to run any serverless function, so calls to get preview times out if it takes longer.
![image](https://user-images.githubusercontent.com/23483005/111584054-42886f00-87b5-11eb-98ac-7181c2c40044.png)


Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
