### PR TITLE
check if thumbnail_image exist

### DIFF
--- a/src/lib/wp/index.js
+++ b/src/lib/wp/index.js
@@ -182,7 +182,7 @@ function wp(site) {
       title: resource.title.rendered,
       // set thumbail from acf | generated thumbnail | Featured Image
       thumbnail_image:
-        resource.acf.attributes.thumbnail_image ||
+        resource.acf?.attributes?.thumbnail_image ||
         resource.featured_image_src ||
         embedded["wp:featuredmedia"][0] ||
         null,


### PR DESCRIPTION
## Description

Some attributes might be empty from the CMS. This PR checks if the `acf.attibutes.thumbail_image` is set.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
