### PR TITLE
[Chore] Switch gitsubmodule to http(s)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 
 [submodule "COMMONS-UI"]
 	path = COMMONS-UI
-	url = git@github.com:CodeForAfrica/COMMONS-UI.git
+	url = https://github.com:CodeForAfrica/COMMONS-UI.git

--- a/src/pages/promises/[...slug].js
+++ b/src/pages/promises/[...slug].js
@@ -144,7 +144,7 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
   }
   const wpApi = wp();
   const page = await wpApi.pages({ slug: "promises", locale }).first;
-  const actNowPage = await wp().pages({ slug: "act-now", locale }).first;
+  const actNowPage = await wpApi.pages({ slug: "act-now", locale }).first;
 
   const { promiseStatuses } = page;
 


### PR DESCRIPTION
## Description

Vercel does not support [ssh](https://vercel.com/docs/build-step#git-submodules) for gitsubmodules. This PR changes the url to `https`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot from 2021-04-08 21-40-17](https://user-images.githubusercontent.com/1779590/114137008-3c009980-9914-11eb-95b5-d8ddda9bbb8e.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
