### PR TITLE
[Feature] Site Configuration

### DIFF
--- a/src/components/AboutPage/index.js
+++ b/src/components/AboutPage/index.js
@@ -15,6 +15,7 @@ import ContentSection from "@/promisetracker/components/ContentPage/Section";
 
 function AboutPage({
   actNow,
+  actNowEnabled,
   content,
   criteria,
   description,
@@ -97,19 +98,22 @@ function AboutPage({
           }}
         />
       </div>
-      <ActNow
-        {...actNow}
-        classes={{
-          section: classes.section,
-          root: classes.actNow,
-        }}
-      />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{
+            section: classes.section,
+            root: classes.actNow,
+          }}
+        />
+      ) : null}
     </ContentPage>
   );
 }
 
 AboutPage.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   content: PropTypes.string,
   criteria: PropTypes.shape({
     items: PropTypes.arrayOf(PropTypes.shape({})),
@@ -127,6 +131,7 @@ AboutPage.propTypes = {
 
 AboutPage.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   content: undefined,
   criteria: undefined,
   description: undefined,

--- a/src/components/ArticleCard/index.js
+++ b/src/components/ArticleCard/index.js
@@ -6,14 +6,14 @@ import useStyles from "./useStyles";
 import Link from "@/promisetracker/components/Link/Button";
 import PostCard from "@/promisetracker/components/PostCard";
 
-function ArticleCard({ classes: classesProp, slug, ...props }) {
+function ArticleCard({ classes: classesProp, href, ...props }) {
   const classes = useStyles({ classes: classesProp });
 
   return (
     <PostCard
       {...props}
-      href={`/analysis/articles/${slug}`}
-      component={Link}
+      component={href ? Link : undefined}
+      href={href}
       classes={{
         root: classes.root,
         content: classes.content,
@@ -45,11 +45,12 @@ ArticleCard.propTypes = {
     title: PropTypes.string,
     titleContainer: PropTypes.string,
   }),
-  slug: PropTypes.string.isRequired,
+  href: PropTypes.string,
 };
 
 ArticleCard.defaultProps = {
   children: undefined,
+  href: undefined,
   classes: undefined,
 };
 

--- a/src/lib/cache/index.js
+++ b/src/lib/cache/index.js
@@ -1,6 +1,8 @@
 import { readFile, writeFile } from "fs/promises";
 import path from "path";
 
+const ARTICLES_CACHE_FILENAME = "articles.json";
+const FACTCHECKS_CACHE_FILENAME = "factchecks.json";
 const PROMISES_CACHE_FILENAME = "promises.json";
 const SITES_CACHE_FILENAME = "sites.json";
 
@@ -47,6 +49,24 @@ function cache(server, fetchFor) {
           return { lastUpdated: Date.now(), data };
         };
         return load(SITES_CACHE_FILENAME, fetchNew);
+      })();
+    },
+    get articles() {
+      return (async () => {
+        const fetchNew = async () => {
+          const data = await fetchFor.articles(this);
+          return { count: data.length, lastUpdated: Date.now(), data };
+        };
+        return load(ARTICLES_CACHE_FILENAME, fetchNew);
+      })();
+    },
+    get factChecks() {
+      return (async () => {
+        const fetchNew = async () => {
+          const data = await fetchFor.factChecks(this);
+          return { count: data.length, lastUpdated: Date.now(), data };
+        };
+        return load(FACTCHECKS_CACHE_FILENAME, fetchNew);
       })();
     },
     get promises() {

--- a/src/lib/jsonql/articles.js
+++ b/src/lib/jsonql/articles.js
@@ -1,0 +1,28 @@
+import { equalsIgnoreCase, slugify } from "@/promisetracker/utils";
+
+function jsonQL(articles) {
+  const allArticles = articles.map((article) => {
+    const slug = article.slug || slugify(article.title);
+    const href = article.href || article.link || `/analysis/articles/${slug}`;
+
+    return { ...article, href, slug };
+  });
+
+  const api = {
+    getArticles({ limit } = {}) {
+      return allArticles.slice(0, limit);
+    },
+    getArticle({ slug, ...others } = {}) {
+      const filteredArticles = api.getArticles(others);
+      if (slug) {
+        return filteredArticles.find((a) => equalsIgnoreCase(a.slug, slug));
+      }
+      const [article] = filteredArticles;
+      return article;
+    },
+  };
+
+  return api;
+}
+
+export default jsonQL;

--- a/src/lib/jsonql/factChecks.js
+++ b/src/lib/jsonql/factChecks.js
@@ -1,0 +1,17 @@
+function jsonQL(factChecks) {
+  const allFactChecks = factChecks.map((fc) => {
+    const href = fc.href || fc.link;
+
+    return { ...fc, href };
+  });
+
+  const api = {
+    getFactChecks({ limit } = {}) {
+      return allFactChecks.slice(0, limit);
+    },
+  };
+
+  return api;
+}
+
+export default jsonQL;

--- a/src/lib/jsonql/promises.js
+++ b/src/lib/jsonql/promises.js
@@ -49,7 +49,7 @@ function jsonQL(promises) {
     getPromise({ id, ...others } = {}) {
       const filteredPromises = api.getPromises(others);
       if (id) {
-        return allPromises.find((p) => equalsIgnoreCase(p.id, id));
+        return filteredPromises.find((p) => equalsIgnoreCase(p.id, id));
       }
       const [promise] = filteredPromises;
       return promise;

--- a/src/pages/about/[slug].js
+++ b/src/pages/about/[slug].js
@@ -46,7 +46,7 @@ export async function getStaticProps({
   const errorCode = notFound ? 404 : null;
 
   const backend = backendFn();
-  const { navigation } = await backend.sites().current;
+  const site = await backend.sites().current;
   const languageAlternates = _.languageAlternates(`/about/${slug}`);
   if (!page && preview) {
     return {
@@ -58,7 +58,7 @@ export async function getStaticProps({
   }
   return {
     notFound,
-    props: { ...page, errorCode, languageAlternates, navigation, slug },
+    props: { ...page, ...site, errorCode, languageAlternates, slug },
     revalidate: 2 * 60, // seconds
   };
 }

--- a/src/pages/act-now.js
+++ b/src/pages/act-now.js
@@ -31,7 +31,7 @@ export async function getStaticProps({ locale }) {
   }
 
   const backend = backendFn();
-  const { navigation } = await backend.sites().current;
+  const site = await backend.sites().current;
   const promises = await backend.promises().all;
 
   const page = await wp().pages({ slug: "act-now", locale }).first;
@@ -53,9 +53,9 @@ export async function getStaticProps({ locale }) {
   return {
     props: {
       ...page,
+      ...site,
       actNow,
       languageAlternates,
-      navigation,
       promises,
     },
     revalidate: 2 * 60, // seconds

--- a/src/pages/analysis/articles/index.js
+++ b/src/pages/analysis/articles/index.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
 
 function Index({
   actNow,
+  actNowEnabled,
   articles,
   footer,
   navigation,
@@ -70,15 +71,17 @@ function Index({
             }}
           />
         </Grid>
-        <Grid item>
-          <ActNow
-            {...actNow}
-            classes={{
-              section: classes.section,
-              root: classes.actNow,
-            }}
-          />
-        </Grid>
+        {actNowEnabled ? (
+          <Grid item>
+            <ActNow
+              {...actNow}
+              classes={{
+                section: classes.section,
+                root: classes.actNow,
+              }}
+            />
+          </Grid>
+        ) : null}
       </Grid>
     </Page>
   );
@@ -86,6 +89,7 @@ function Index({
 
 Index.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   articles: PropTypes.arrayOf(PropTypes.shape({})),
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
@@ -94,8 +98,9 @@ Index.propTypes = {
 };
 
 Index.defaultProps = {
-  articles: undefined,
+  actNowEnabled: undefined,
   actNow: undefined,
+  articles: undefined,
   footer: undefined,
   navigation: undefined,
   subscribe: undefined,
@@ -112,7 +117,6 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
   const wpApi = wp();
   const page = await wpApi.pages({ slug: "analysis-articles", locale }).first;
   const posts = await wpApi.pages({ page }).posts;
@@ -123,9 +127,9 @@ export async function getStaticProps({ locale }) {
   return {
     props: {
       ...page,
+      ...site,
       articles,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };

--- a/src/pages/analysis/fact-checks.js
+++ b/src/pages/analysis/fact-checks.js
@@ -10,7 +10,6 @@ import Page from "@/promisetracker/components/Page";
 import PostCardGrid from "@/promisetracker/components/PostCardGrid";
 import backendFn from "@/promisetracker/lib/backend";
 import i18n from "@/promisetracker/lib/i18n";
-import pc from "@/promisetracker/lib/pc";
 import wp from "@/promisetracker/lib/wp";
 
 const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
@@ -33,6 +32,7 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
 
 function FactChecks({
   actNow,
+  actNowEnabled,
   factChecks,
   footer,
   navigation,
@@ -71,15 +71,17 @@ function FactChecks({
             }}
           />
         </Grid>
-        <Grid item>
-          <ActNow
-            {...actNow}
-            classes={{
-              section: classes.section,
-              root: classes.actNow,
-            }}
-          />
-        </Grid>
+        {actNowEnabled ? (
+          <Grid item>
+            <ActNow
+              {...actNow}
+              classes={{
+                section: classes.section,
+                root: classes.actNow,
+              }}
+            />
+          </Grid>
+        ) : null}
       </Grid>
     </Page>
   );
@@ -87,6 +89,7 @@ function FactChecks({
 
 FactChecks.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   factChecks: PropTypes.arrayOf(PropTypes.shape({})),
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
@@ -96,6 +99,7 @@ FactChecks.propTypes = {
 
 FactChecks.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   factChecks: undefined,
   footer: undefined,
   navigation: undefined,
@@ -113,17 +117,16 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
+  const factChecks = await backend.factChecks().all;
   const page = await wp().pages({ slug: "analysis-fact-checks", locale }).first;
-  const factChecks = await pc().factChecks().latest;
   const languageAlternates = _.languageAlternates("/analysis/fact-checks");
 
   return {
     props: {
       ...page,
+      ...site,
       factChecks,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };

--- a/src/pages/analysis/petitions/[slug].js
+++ b/src/pages/analysis/petitions/[slug].js
@@ -171,7 +171,7 @@ export async function getStaticProps({
   }
 
   const backend = backendFn();
-  const { navigation } = await backend.sites().current;
+  const site = await backend.sites().current;
   const errorCode = notFound ? 404 : null;
   const page = await wpApi.pages({ slug: "analysis-articles" }).first;
   const posts = await wpApi.pages({ page }).posts;
@@ -191,10 +191,10 @@ export async function getStaticProps({
   return {
     props: {
       ...page,
+      ...site,
       article,
       errorCode,
       languageAlternates,
-      navigation,
       relatedArticles,
     },
     revalidate: 2 * 60, // seconds

--- a/src/pages/analysis/petitions/index.js
+++ b/src/pages/analysis/petitions/index.js
@@ -101,6 +101,7 @@ function Index({
 
 Index.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
   petitions: PropTypes.arrayOf(PropTypes.shape({})),
@@ -110,6 +111,7 @@ Index.propTypes = {
 
 Index.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   footer: undefined,
   navigation: undefined,
   petitions: undefined,
@@ -126,7 +128,7 @@ export async function getStaticProps({ locale }) {
   }
 
   const backend = backendFn();
-  const { navigation } = await backend.sites().current;
+  const site = await backend.sites().current;
   const wpApi = wp();
   const page = await wpApi.pages({ slug: "analysis-petitions", locale }).first;
   page.posts = null;
@@ -136,8 +138,8 @@ export async function getStaticProps({ locale }) {
   return {
     props: {
       ...page,
+      ...site,
       languageAlternates,
-      navigation,
       petitions,
     },
   };

--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -25,7 +25,14 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
   },
 }));
 
-function FaqPage({ actNow, faqs, footer, navigation, ...props }) {
+function FaqPage({
+  actNow,
+  actNowEnabled,
+  faqs,
+  footer,
+  navigation,
+  ...props
+}) {
   const classes = useStyles(props);
 
   return (
@@ -39,13 +46,21 @@ function FaqPage({ actNow, faqs, footer, navigation, ...props }) {
         lg: 8,
       }}
     >
-      <ActNow {...actNow} classes={{ section: classes.section }} />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{
+            section: classes.section,
+          }}
+        />
+      ) : null}
     </ContentPage>
   );
 }
 
 FaqPage.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
   faqs: PropTypes.arrayOf(PropTypes.shape({})),
@@ -53,6 +68,7 @@ FaqPage.propTypes = {
 
 FaqPage.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   footer: undefined,
   navigation: undefined,
   faqs: undefined,
@@ -68,7 +84,6 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
   const page = await wp().pages({ slug: "faq", locale }).first;
   const faqs = page.faqs
     .reduce((arr, e) => arr.concat(e.questions_answers), [])
@@ -78,9 +93,9 @@ export async function getStaticProps({ locale }) {
   return {
     props: {
       ...page,
+      ...site,
       faqs,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -33,6 +33,7 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
 
 function Index({
   actNow,
+  actNowEnabled,
   articles,
   criteria,
   footer,
@@ -91,12 +92,14 @@ function Index({
           section: classes.section,
         }}
       />
-      <ActNow
-        {...actNow}
-        classes={{
-          section: classes.section,
-        }}
-      />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{
+            section: classes.section,
+          }}
+        />
+      ) : null}
       <LatestArticles
         actionLabel="See All"
         items={articles}
@@ -123,6 +126,7 @@ function Index({
 
 Index.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   articles: PropTypes.arrayOf(PropTypes.shape({})),
   criteria: PropTypes.shape({}),
   footer: PropTypes.shape({}),
@@ -148,6 +152,7 @@ Index.propTypes = {
 
 Index.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   articles: undefined,
   criteria: undefined,
   footer: undefined,
@@ -189,8 +194,9 @@ export async function getStaticProps({ locale }) {
   //   limit: 6,
   //   query: `{ "projects": ["4691"] }`,
   // });
-  const posts = await wpApi.pages({ slug: "analysis-articles", locale }).posts;
-  const articles = posts?.slice(0, 4) || null;
+  const articles = (await backend.articles().all)?.slice(0, 4) ?? null;
+  // const posts = await wpApi.pages({ slug: "analysis-articles", locale }).posts;
+  // const articles = posts?.slice(0, 4) || null;
   // const projectMeta = await api.projectMeta();
   const projectApi = backend.project();
   const site = await backend.sites().current;

--- a/src/pages/join.js
+++ b/src/pages/join.js
@@ -31,7 +31,14 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
   },
 }));
 
-function Join({ actNow, description, footer, navigation, ...props }) {
+function Join({
+  actNow,
+  actNowEnabled,
+  description,
+  footer,
+  navigation,
+  ...props
+}) {
   const classes = useStyles(props);
 
   return (
@@ -51,18 +58,21 @@ function Join({ actNow, description, footer, navigation, ...props }) {
         ) : null
       }
     >
-      <ActNow
-        {...actNow}
-        classes={{
-          section: classes.section,
-        }}
-      />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{
+            section: classes.section,
+          }}
+        />
+      ) : null}
     </ContentPage>
   );
 }
 
 Join.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   description: PropTypes.string,
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
@@ -70,6 +80,7 @@ Join.propTypes = {
 
 Join.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   description: undefined,
   footer: undefined,
   navigation: undefined,
@@ -85,15 +96,14 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
   const page = await wp().pages({ slug: "join", locale }).first;
   const languageAlternates = _.languageAlternates("/join");
 
   return {
     props: {
       ...page,
+      ...site,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };

--- a/src/pages/legal/[slug].js
+++ b/src/pages/legal/[slug].js
@@ -28,7 +28,6 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
   const slug = slugParam.toLowerCase();
   const pages = await wp().pages({ slug: "legal", locale }).children;
   const index = pages.findIndex((page) => page.slug === slug);
@@ -39,7 +38,7 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
 
   return {
     notFound,
-    props: { ...page, errorCode, slug, languageAlternates, navigation },
+    props: { ...page, ...site, errorCode, slug, languageAlternates },
     revalidate: 2 * 60, // seconds
   };
 }

--- a/src/pages/promises/[...slug].js
+++ b/src/pages/promises/[...slug].js
@@ -171,7 +171,6 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
   const promisePost = await backend.promises({ id }).first;
   const promiseStatuses = await backend.promises({ id }).statuses;
   const site = await backend.sites().current;
-  const { navigation } = site;
 
   const notFound = !promisePost;
   if (notFound) {
@@ -207,10 +206,10 @@ export async function getStaticProps({ params: { slug: slugParam }, locale }) {
   return {
     props: {
       ...page,
+      ...site,
       ...actNowPage,
       errorCode,
       languageAlternates,
-      navigation,
       promise,
       promiseStatuses,
     },

--- a/src/pages/promises/index.js
+++ b/src/pages/promises/index.js
@@ -37,6 +37,7 @@ function PromisesPage({
   navigation,
   promises,
   actNow,
+  actNowEnabled,
   subscribe,
   title,
   projectMeta,
@@ -63,10 +64,12 @@ function PromisesPage({
           section: classes.section,
         }}
       />
-      <ActNow
-        {...actNow}
-        classes={{ section: classes.section, root: classes.actNow }}
-      />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{ section: classes.section, root: classes.actNow }}
+        />
+      ) : null}
       <Subscribe
         {...subscribe}
         classes={{
@@ -79,6 +82,7 @@ function PromisesPage({
 
 PromisesPage.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   footer: PropTypes.shape({}),
   projectMeta: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
@@ -91,6 +95,7 @@ PromisesPage.propTypes = {
 
 PromisesPage.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   promises: undefined,
   sortLabels: undefined,
   promiseStatuses: undefined,
@@ -113,7 +118,11 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const sitesApi = backend.sites();
-  const { navigation, statuses: promiseStatuses } = await sitesApi.current;
+  const {
+    navigation,
+    statuses: promiseStatuses,
+    ...site
+  } = await sitesApi.current;
   const projectApi = backend.project();
   const projectMeta = await projectApi.meta;
 
@@ -125,6 +134,7 @@ export async function getStaticProps({ locale }) {
   return {
     props: {
       ...page,
+      ...site,
       languageAlternates,
       navigation,
       promises,

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -31,7 +31,14 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
   },
 }));
 
-function Resources({ actNow, description, footer, navigation, ...props }) {
+function Resources({
+  actNow,
+  actNowEnabled,
+  description,
+  footer,
+  navigation,
+  ...props
+}) {
   const classes = useStyles(props);
 
   return (
@@ -51,18 +58,21 @@ function Resources({ actNow, description, footer, navigation, ...props }) {
         ) : null
       }
     >
-      <ActNow
-        {...actNow}
-        classes={{
-          section: classes.section,
-        }}
-      />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{
+            section: classes.section,
+          }}
+        />
+      ) : null}
     </ContentPage>
   );
 }
 
 Resources.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   description: PropTypes.string,
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
@@ -70,6 +80,7 @@ Resources.propTypes = {
 
 Resources.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   description: undefined,
   footer: undefined,
   navigation: undefined,
@@ -85,15 +96,14 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
   const page = await wp().pages({ slug: "resources", locale }).first;
   const languageAlternates = _.languageAlternates("/resources");
 
   return {
     props: {
       ...page,
+      ...site,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };

--- a/src/pages/subscribe.js
+++ b/src/pages/subscribe.js
@@ -25,7 +25,14 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
   },
 }));
 
-function SubscribePage({ actNow, footer, navigation, subscribe, ...props }) {
+function SubscribePage({
+  actNow,
+  actNowEnabled,
+  footer,
+  navigation,
+  subscribe,
+  ...props
+}) {
   const classes = useStyles(props);
 
   return (
@@ -36,13 +43,21 @@ function SubscribePage({ actNow, footer, navigation, subscribe, ...props }) {
       classes={{ section: classes.section, footer: classes.footer }}
     >
       <Subscribe {...subscribe} classes={{ section: classes.section }} />
-      <ActNow {...actNow} classes={{ section: classes.section }} />
+      {actNowEnabled ? (
+        <ActNow
+          {...actNow}
+          classes={{
+            section: classes.section,
+          }}
+        />
+      ) : null}
     </Page>
   );
 }
 
 SubscribePage.propTypes = {
   actNow: PropTypes.shape({}),
+  actNowEnabled: PropTypes.bool,
   footer: PropTypes.shape({}),
   navigation: PropTypes.shape({}),
   subscribe: PropTypes.shape({}),
@@ -50,6 +65,7 @@ SubscribePage.propTypes = {
 
 SubscribePage.defaultProps = {
   actNow: undefined,
+  actNowEnabled: undefined,
   footer: undefined,
   navigation: undefined,
   subscribe: undefined,
@@ -65,15 +81,14 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
-  const { navigation } = site;
   const page = await wp().pages({ slug: "subscribe", locale }).first;
   const languageAlternates = _.languageAlternates("/subscribe");
 
   return {
     props: {
       ...page,
+      ...site,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };


### PR DESCRIPTION
## Description

Since we now can configure site features from a gsheet, the next step is to enable/disable components based on site configuration. With this PR, we can:

  - [x] Enable / disable actNow component on all pages depending on whether actNow is enabled on the site,
  - [x] Enable / disable articles (Latest articles on homepage) depending on whether articles are enabled on the site,
  - [x] Load fact checks depending on whether fact checks are enabled on the site.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

![Screenshot 2021-09-16 at 17-47-54 PromiseTracker](https://user-images.githubusercontent.com/1779590/133634461-ad7ffbe3-c671-4af5-963f-8ab3ec38d333.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

