### PR TITLE
[Feat] Hide pages when corresponding feature is disabled

### DIFF
--- a/src/pages/act-now.js
+++ b/src/pages/act-now.js
@@ -32,6 +32,12 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
+  if (!site.actNowEnabled) {
+    return {
+      notFound: true,
+    };
+  }
+
   const promises = await backend.promises().all;
 
   const page = await wp().pages({ slug: "act-now", locale }).first;

--- a/src/pages/analysis/articles/index.js
+++ b/src/pages/analysis/articles/index.js
@@ -117,6 +117,12 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
+  if (!site.articlesEnabled) {
+    return {
+      notFound: true,
+    };
+  }
+
   const wpApi = wp();
   const page = await wpApi.pages({ slug: "analysis-articles", locale }).first;
   const posts = await wpApi.pages({ page }).posts;

--- a/src/pages/analysis/fact-checks.js
+++ b/src/pages/analysis/fact-checks.js
@@ -117,6 +117,12 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
+  if (!site.factChecksEnabled) {
+    return {
+      notFound: true,
+    };
+  }
+
   const factChecks = await backend.factChecks().all;
   const page = await wp().pages({ slug: "analysis-fact-checks", locale }).first;
   const languageAlternates = _.languageAlternates("/analysis/fact-checks");

--- a/src/pages/analysis/petitions/index.js
+++ b/src/pages/analysis/petitions/index.js
@@ -129,6 +129,12 @@ export async function getStaticProps({ locale }) {
 
   const backend = backendFn();
   const site = await backend.sites().current;
+  if (!site.actNowEnabled) {
+    return {
+      notFound: true,
+    };
+  }
+
   const wpApi = wp();
   const page = await wpApi.pages({ slug: "analysis-petitions", locale }).first;
   page.posts = null;

--- a/src/pages/analysis/resources.js
+++ b/src/pages/analysis/resources.js
@@ -84,15 +84,21 @@ export async function getStaticProps({ locale }) {
   }
 
   const backend = backendFn();
-  const { navigation } = await backend.sites().current;
+  const site = await backend.sites().current;
+  if (!site.resourcesEnabled) {
+    return {
+      notFound: true,
+    };
+  }
+
   const page = await wp().pages({ slug: "resources", locale }).first;
   const languageAlternates = _.languageAlternates("/analysis/resources");
 
   return {
     props: {
       ...page,
+      ...site,
       languageAlternates,
-      navigation,
     },
     revalidate: 2 * 60, // seconds
   };


### PR DESCRIPTION
## Description

This PR ensures 404 is returned when user tries to access a page for a feature that is disabled: These include:

 - [x] `/act-now` when **actNOW** is disabled.
 - [x] `/analysis/petitions` when **actNOW** is disabled.
 - [x] `/analysis/articles` when **Articles** is disabled.
 - [x] `/analysis/fact-checks` when **Fact-Checks** is disabled.
 - [x] `/analysis/resources` when **Resources** is disabled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Screenshot from 2022-01-13 17-52-44](https://user-images.githubusercontent.com/1779590/149354785-214cb8c8-db2e-4076-9206-2a61e5df2fc6.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

