### PR TITLE
feat(cms): add image and social links fields to site settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Source: `src/` (Next.js + Payload CMS)
+  - App routes: `src/app/` (frontend and admin payload segments)
+  - CMS: `src/collections/`, `src/globals/`, `src/blocks/`, `src/fields/`
+  - Utilities & libs: `src/utils/`, `src/lib/`, `src/types/`
+  - Jobs & workflows: `src/tasks/`, `src/workflows/`
+  - Config: `src/payload.config.ts`, `next.config.mjs`
+- Tests: `tests/int` (Vitest) and `tests/e2e` (Playwright)
+- Assets/media: `media/`
+
+## Build, Test, and Development Commands
+- Install: `pnpm i`
+- Dev server: `pnpm dev` (Next.js + Payload; use `.env` or `.env.local`)
+- Clean dev cache: `pnpm devsafe`
+- Build: `pnpm build`; Start: `pnpm start`
+- Lint: `pnpm lint`
+- Tests (all): `pnpm test` → runs `test:int` and `test:e2e`
+- Int tests: `pnpm test:int` (Vitest, JSDOM)
+- E2E tests: `pnpm test:e2e` (Playwright, auto-starts dev server)
+- Payload types/import map: `pnpm generate:all`
+- Airtable typings: `pnpm generate:airtable` (requires `AIRTABLE_*` envs)
+- Optional: Start Apache Tika for document processing: `docker compose up -d`
+
+## Coding Style & Naming Conventions
+- Language: TypeScript (`.ts`, `.tsx`), 2-space indent.
+- Framework: Next.js App Router; React components in `src/components/` use PascalCase.
+- Linting: ESLint (`eslint.config.mjs`, Next + TS rules); Formatting: Prettier defaults.
+- Paths: Prefer TS path aliases (see `tsconfig.json`).
+
+## Testing Guidelines
+- Frameworks: Vitest (integration) and Playwright (e2e).
+- Naming: `tests/int/**/*.int.spec.ts`, `tests/e2e/**/*.e2e.spec.ts`.
+- Run locally before PR: `pnpm test:int && pnpm test:e2e`.
+- Write tests for new collections, fields, and critical flows.
+
+## Commit & Pull Request Guidelines
+- Commit style follows Conventional Commits seen in history: `feat(...)`, `fix(...)`, `refactor(...)`, `build(deps)`, etc.
+- PRs: clear description, link issues, include screenshots for UI, list env/config changes, and note any migrations.
+- CI hygiene: ensure `pnpm lint` and all tests pass; update docs when behavior changes.
+
+## Security & Configuration Tips
+- Env files: `.env.example` documents required keys (Airtable, CheckDesk, Gemini). Do not commit secrets.
+- Engines: Node `^18.20.2 || >=20.9.0`, PNPM `^9 || ^10`.

--- a/src/collections/SiteSettings/tabs/EngagementTab.ts
+++ b/src/collections/SiteSettings/tabs/EngagementTab.ts
@@ -1,3 +1,4 @@
+import { socialLinks } from "@/fields/socialLinks";
 import { Tab } from "payload";
 
 export const EngagementTab: Tab = {
@@ -5,5 +6,41 @@ export const EngagementTab: Tab = {
     en: "Engagement",
     fr: "Fiançailles",
   },
-  fields: [],
+  fields: [
+    {
+      name: "connect",
+      type: "group",
+      label: {
+        en: "Social Accounts",
+        fr: "Comptes sociaux",
+      },
+      fields: [
+        {
+          type: "collapsible",
+          label: {
+            en: "Title & Links",
+            fr: "Titre et liens",
+          },
+          fields: [
+            {
+              name: "title",
+              type: "text",
+              required: true,
+              label: {
+                en: "Title",
+                fr: "Titre",
+              },
+              admin: {
+                description: {
+                  en: "Text that appears on contact links e.g Stay in Touch",
+                  fr: "Texte qui apparaît sur les liens de contact, par exemple «Restez en contact»",
+                },
+              },
+            },
+            socialLinks(),
+          ],
+        },
+      ],
+    },
+  ],
 };

--- a/src/collections/SiteSettings/tabs/GeneralTab.ts
+++ b/src/collections/SiteSettings/tabs/GeneralTab.ts
@@ -1,3 +1,4 @@
+import { image } from "@/fields/image";
 import { Tab } from "payload";
 
 export const GeneralTab: Tab = {
@@ -32,27 +33,34 @@ export const GeneralTab: Tab = {
         fr: "Logo",
       },
       fields: [
-        {
+        image({
           name: "primaryLogo",
+          label: {
+            en: "Primary Logo",
+            fr: "Logo principal",
+          },
           required: true,
           admin: {
-            description: "Shown on main navigation bar.",
+            description: {
+              en: "Shown on main navigation bar.",
+              fr: "Affiché sur la barre de navigation principale.",
+            },
           },
-          type: "relationship",
-          relationTo: "media",
-          hasMany: false,
-        },
-        {
+        }),
+        image({
           name: "secondaryLogo",
           required: true,
-          admin: {
-            description:
-              "Shown on main footer. If not provided, primary logo will be reused.",
+          label: {
+            en: "Secondary Logo",
+            fr: "Logo secondaire",
           },
-          type: "relationship",
-          relationTo: "media",
-          hasMany: false,
-        },
+          admin: {
+            description: {
+              en: "Shown on main footer. If not provided, primary logo will be reused.",
+              fr: "Affiché dans le pied de page principal. S'il n'est pas fourni, le logo principal sera réutilisé.",
+            },
+          },
+        }),
       ],
     },
   ],

--- a/src/fields/image.ts
+++ b/src/fields/image.ts
@@ -1,0 +1,14 @@
+import { Field, deepMerge } from "payload";
+
+export const image = (overrides: Partial<Field> = {}) => {
+  const defaults: Field = {
+    name: "image",
+    type: "upload",
+    relationTo: "media",
+    filterOptions: {
+      mimeType: { contains: "image" },
+    },
+  };
+
+  return deepMerge(defaults, overrides);
+};

--- a/src/fields/socialLinks.ts
+++ b/src/fields/socialLinks.ts
@@ -1,0 +1,44 @@
+import { deepMerge, Field } from "payload";
+import { url } from "./url";
+
+export const socialMediaOptions = [
+  "Facebook",
+  "Twitter",
+  "Instagram",
+  "Linkedin",
+  "Github",
+  "Slack",
+];
+
+export const socialLinks = (overrides: Partial<Field> = {}) => {
+  const defaults: Field = {
+    name: "links",
+    type: "array",
+    labels: {
+      singular: {
+        en: "Link",
+        fr: "Lien",
+      },
+      plural: {
+        en: "Links",
+        fr: "Links",
+      },
+    },
+    minRows: 1,
+    fields: [
+      {
+        name: "platform",
+        type: "select",
+        options: socialMediaOptions,
+        required: true,
+      },
+      url({
+        overrides: {
+          required: true,
+        },
+      }),
+    ],
+  };
+
+  return deepMerge(defaults, overrides);
+};

--- a/src/fields/url.ts
+++ b/src/fields/url.ts
@@ -1,0 +1,34 @@
+import { type Field, ValidationError, deepMerge } from "payload";
+
+interface Args {
+  overrides?: Partial<Field>;
+}
+export const url = ({ overrides = {} }: Args = {}): Field => {
+  const urlResult: Field = {
+    name: "url",
+    type: "text",
+    label: "URL",
+    validate: (value: string | undefined | null) => {
+      if (!value) return true; // Assuming we can allow empty values
+
+      try {
+        new URL(value);
+      } catch (e) {
+        if (e instanceof TypeError) {
+          throw new ValidationError({
+            errors: [
+              {
+                message: "Please enter a valid URL",
+                path: "url",
+              },
+            ],
+          });
+        }
+        return "Please enter valid URL";
+      }
+      return true;
+    },
+  };
+
+  return deepMerge(urlResult, overrides);
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -425,6 +425,19 @@ export interface SiteSetting {
         }[]
       | null;
   };
+  connect: {
+    /**
+     * Text that appears on contact links e.g Stay in Touch
+     */
+    title: string;
+    links?:
+      | {
+          platform: 'Facebook' | 'Twitter' | 'Instagram' | 'Linkedin' | 'Github' | 'Slack';
+          url: string;
+          id?: string | null;
+        }[]
+      | null;
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -810,6 +823,18 @@ export interface SiteSettingsSelect<T extends boolean = true> {
                     url?: T;
                     label?: T;
                   };
+              id?: T;
+            };
+      };
+  connect?:
+    | T
+    | {
+        title?: T;
+        links?:
+          | T
+          | {
+              platform?: T;
+              url?: T;
               id?: T;
             };
       };


### PR DESCRIPTION
## Description

- Implement reusable field components for image uploads and social media links
- Add social media connection section to engagement tab
- Replace direct relationship fields with the image field component in the general tab

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
