### PR TITLE
refactor(domain): Fix Root Domain

### DIFF
--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,52 +1,90 @@
 "use server";
 import { headers as getHeaders } from "next/headers";
 
+// Try to derive a canonical host from NEXT_PUBLIC_APP_URL so we can tell when the
+// request matches the root site (e.g. promisetracker-v2.dev.codeforafrica.org)
+// versus a tenant subdomain such as ken.promisetracker-v2.dev.codeforafrica.org.
+const appHost = (() => {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) return null;
+
+  try {
+    const parsed = new URL(appUrl);
+    return {
+      hostname: parsed.hostname.toLowerCase(),
+      port: parsed.port ? `:${parsed.port}` : "",
+    } as const;
+  } catch {
+    return null;
+  }
+})();
+
 export const getDomain = async () => {
   const headers = await getHeaders();
   const host = headers.get("host");
-  const isLocalhost = host?.includes("localhost") ?? false;
 
-  let baseDomain = host;
   let hostname: string | null = null;
   let port = "";
 
   if (host) {
-    // Extract port if present
-    const hostParts = host.split(":");
-    if (hostParts.length > 1) {
-      port = `:${hostParts[1]}`;
-    }
-
-    hostname = hostParts[0] || null;
-
-    // Extract base domain without the leading tenant subdomain
-    const domainParts = hostname?.split(".") ?? [];
-
-    if (domainParts.length > 2) {
-      // Keep all segments after the tenant label to preserve environment prefixes (e.g. staging.example.com)
-      baseDomain = `${domainParts.slice(1).join(".")}${port}`;
-    } else if (hostname) {
-      baseDomain = `${hostname}${port}`;
+    // Split off any port (e.g. localhost:3000) and normalise the hostname.
+    const [rawHostname, rawPort] = host.split(":");
+    hostname = rawHostname || null;
+    if (rawPort) {
+      port = `:${rawPort}`;
     }
   }
 
+  const normalizedHostname = hostname?.toLowerCase() ?? "";
+  const isLocalhost = normalizedHostname.includes("localhost");
+
+  let baseDomain = host ?? "";
   let subdomain: string | null = null;
-  if (host) {
-    const parts = host.split(".");
-    // Only extract subdomain if it's a pattern like api.example.com
-    // For example.com, subdomain will remain null
-    if (parts.length > 2) {
-      subdomain = parts[0];
+
+  if (hostname) {
+    if (appHost) {
+      const { hostname: canonicalHost, port: canonicalPort } = appHost;
+
+      if (normalizedHostname === canonicalHost) {
+        // Exact match with the configured host (e.g. promisetracker-v2.dev.codeforafrica.org) — keep the root domain.
+        baseDomain = `${hostname}${port}`;
+      } else if (normalizedHostname.endsWith(`.${canonicalHost}`)) {
+        // Host looks like `<tenant>.<canonical>` (e.g. ken.promisetracker-v2.dev.codeforafrica.org) — capture the tenant
+        // and force the base domain to the canonical host so generated links stay stable.
+        const suffixLength = canonicalHost.length + 1;
+        const prefix = normalizedHostname.slice(0, -suffixLength);
+        const segments = prefix.split(".").filter(Boolean);
+        subdomain = segments.pop() ?? null;
+        const effectivePort = canonicalPort || port;
+        baseDomain = `${canonicalHost}${effectivePort}`;
+      } else {
+        // Host does not match our configured base (e.g. unexpected.example.com) — fall back to the raw host.
+        baseDomain = `${hostname}${port}`;
+        const segments = normalizedHostname.split(".");
+        if (segments.length > 2) {
+          // Treat the leading label as the tenant when there are 3+ segments.
+          subdomain = segments.shift() ?? null;
+          baseDomain = `${segments.join(".")}${port}`;
+        }
+      }
+    } else {
+      // No configured app host — strip the leading label when the host is a
+      // subdomain (e.g. api.localhost) so we still surface a link back to the root tenant selector.
+      baseDomain = `${hostname}${port}`;
+      const segments = normalizedHostname.split(".");
+      if (segments.length > 2) {
+        subdomain = segments.shift() ?? null;
+        baseDomain = `${segments.join(".")}${port}`;
+      }
     }
   }
 
-  const normalizedHost = hostname?.toLowerCase() ?? "";
-  const normalizedBaseDomain = baseDomain?.toLowerCase() ?? "";
+  const normalizedBaseDomain = baseDomain.toLowerCase();
   const isLocalEnvironment =
     isLocalhost ||
-    normalizedHost.includes("localtest") ||
-    normalizedHost.startsWith("127.") ||
-    normalizedHost === "0.0.0.0" ||
+    normalizedHostname.includes("localtest") ||
+    normalizedHostname.startsWith("127.") ||
+    normalizedHostname === "0.0.0.0" ||
     normalizedBaseDomain.includes("localhost") ||
     normalizedBaseDomain.startsWith("127.") ||
     normalizedBaseDomain === "0.0.0.0";


### PR DESCRIPTION
## Description
Improve domain parsing logic with canonical host support
Add support for deriving a canonical host from NEXT_PUBLIC_APP_URL to better handle tenant subdomains. Simplify host parsing logic and improve handling of edge cases like local environments and unexpected domains.

Fixes # (issue)
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
