### PR TITLE
feat(global-pages): add support for global pages in navigation and links

### DIFF
--- a/src/app/(frontend)/[...slugs]/page.tsx
+++ b/src/app/(frontend)/[...slugs]/page.tsx
@@ -242,10 +242,7 @@ export default async function Page(params: Args) {
           Boolean(col)
         ) || [];
 
-    const navigationForTenant =
-      entityNavMenus.length > 0
-        ? { ...navigation, menus: entityNavMenus }
-        : navigation;
+    const navigationForEntity = { ...navigation, menus: entityNavMenus };
 
     const footerForTenant =
       entitySecondaryNavColumns.length > 0
@@ -256,7 +253,7 @@ export default async function Page(params: Args) {
       <>
         <Navigation
           title={title}
-          {...navigationForTenant}
+          {...navigationForEntity}
           tenantSelectionHref={tenantSelectionHref}
         />
         <Suspense>

--- a/src/collections/Pages/GlobalPages.ts
+++ b/src/collections/Pages/GlobalPages.ts
@@ -1,5 +1,5 @@
 import { CollectionConfig } from "payload";
-import { ensureUniqueSlug } from "./hooks/ensureUniqueSlug";
+import { ensureUniqueGlobalPageSlug } from "./hooks/ensureUniqueSlug";
 import Partners from "@/blocks/Partners";
 import Newsletter from "@/blocks/Newsletter";
 import { slugField } from "@/fields/slug";
@@ -38,7 +38,7 @@ export const GlobalPages: CollectionConfig = {
           position: "sidebar",
         },
         hooks: {
-          beforeValidate: [ensureUniqueSlug],
+          beforeValidate: [ensureUniqueGlobalPageSlug],
         },
       },
     }),

--- a/src/collections/Pages/hooks/ensureUniqueSlug.ts
+++ b/src/collections/Pages/hooks/ensureUniqueSlug.ts
@@ -54,3 +54,57 @@ export const ensureUniqueSlug: FieldHook<Page> = async ({
 
   return value;
 };
+
+export const ensureUniqueGlobalPageSlug: FieldHook<Page> = async ({
+  data,
+  originalDoc,
+  req,
+  value,
+}) => {
+  if (originalDoc?.slug === value) {
+    return value;
+  }
+
+  const constraints: Where[] = [
+    {
+      slug: {
+        equals: value,
+      },
+    },
+  ];
+
+  if (data?.tenant) {
+    constraints.push({
+      tenant: {
+        equals: data.tenant,
+      },
+    });
+  }
+
+  const { docs: duplicates } = await req.payload.find({
+    collection: "global-pages",
+    where: {
+      and: constraints,
+    },
+  });
+  if (duplicates.length > 0) {
+    const { docs: tenant } = await req.payload.find({
+      collection: "tenants",
+      where: {
+        id: {
+          equals: data?.tenant,
+        },
+      },
+    });
+    throw new ValidationError({
+      errors: [
+        {
+          message: `The ${tenant[0]?.name} tenant already has a page with the slug "${value}". Slugs must be unique per tenant`,
+          path: "slug",
+        },
+      ],
+    });
+  }
+
+  return value;
+};

--- a/src/components/ActNowCard/PetitionCard.tsx
+++ b/src/components/ActNowCard/PetitionCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Snackbar } from "@mui/material";
+import { Box, Snackbar } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import React, { useState } from "react";
 
@@ -27,13 +27,14 @@ function PetitionCard({
   },
   ...props
 }: PetitionCardProps) {
+  const [success, setSuccess] = useState(false);
+
   if (!promiseActNow.petition) return null;
   const {
     petition: { petitionTitle, petitionDescription },
   } = promiseActNow;
 
   const { petitionJoin, petitionTitle: petitionStart } = props;
-  const [success, setSuccess] = useState(false);
 
   const handleSnackbarClose = () => {
     setSuccess(false);

--- a/src/fields/link/link.ts
+++ b/src/fields/link/link.ts
@@ -95,7 +95,7 @@ export const link: LinkType = ({
         en: "Document to link to",
         fr: "Document vers lequel créer un lien",
       },
-      relationTo: ["pages"],
+      relationTo: ["pages", "global-pages"],
       required: true,
     },
     {
@@ -148,7 +148,7 @@ export const link: LinkType = ({
 
     if (appearances) {
       appearanceOptionsToUse = appearances.map(
-        (appearance) => appearanceOptions[appearance],
+        (appearance) => appearanceOptions[appearance]
       );
     }
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -453,16 +453,52 @@ export interface ActNowBlock {
   link: {
     type?: ('reference' | 'custom') | null;
     newTab?: boolean | null;
-    reference?: {
-      relationTo: 'pages';
-      value: string | Page;
-    } | null;
+    reference?:
+      | ({
+          relationTo: 'pages';
+          value: string | Page;
+        } | null)
+      | ({
+          relationTo: 'global-pages';
+          value: string | GlobalPage;
+        } | null);
     url?: string | null;
     label: string;
   };
   id?: string | null;
   blockName?: string | null;
   blockType: 'act-now';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "global-pages".
+ */
+export interface GlobalPage {
+  id: string;
+  title: string;
+  slug: string;
+  slugLock?: boolean | null;
+  blocks?:
+    | (
+        | ActNowBlock
+        | FAQBlock
+        | NewsletterBlock
+        | PageHeaderBlock
+        | PartnersBlock
+        | PartnerDetailsBlock
+        | TenantSelectorBlock
+      )[]
+    | null;
+  meta?: {
+    title?: string | null;
+    description?: string | null;
+    /**
+     * Maximum upload file size: 12MB. Recommended file size for images is <500KB.
+     */
+    image?: (string | null) | Media;
+  };
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -492,83 +528,6 @@ export interface FAQBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'faq';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "HeroBlock".
- */
-export interface HeroBlock {
-  /**
-   * Displayed alongside the political entity name in the hero.
-   */
-  tagline?: string | null;
-  /**
-   * Label displayed beside the total count of synced promises.
-   */
-  promiseLabel?: string | null;
-  /**
-   * Sentence that follows the promise count, for example 'tracked on PromiseTracker'.
-   */
-  trailText?: string | null;
-  updatedAtLabel?: string | null;
-  /**
-   * Optional text that replaces the political entity position shown above the last updated date.
-   */
-  profileTitleOverride?: string | null;
-  statusListTitle?: string | null;
-  /**
-   * Define exactly three groups of promise statuses to display in the charts.
-   */
-  chartGroups: {
-    title: string;
-    statuses: (string | PromiseStatus)[];
-    id?: string | null;
-  }[];
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'hero';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "KeyPromisesBlock".
- */
-export interface KeyPromisesBlock {
-  title: string;
-  actionLabel?: string | null;
-  /**
-   * How many highlighted promises to display (minimum 1).
-   */
-  itemsToShow: number;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'key-promises';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "LatestPromisesBlock".
- */
-export interface LatestPromisesBlock {
-  title: string;
-  /**
-   * Link to the page where all promises can be viewed. E.g. /promises
-   */
-  seeAllLink: {
-    type?: ('reference' | 'custom') | null;
-    newTab?: boolean | null;
-    reference?: {
-      relationTo: 'pages';
-      value: string | Page;
-    } | null;
-    url?: string | null;
-    label: string;
-    /**
-     * Choose how the link should be rendered.
-     */
-    appearance?: ('default' | 'outline') | null;
-  };
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'latest-promises';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -643,10 +602,15 @@ export interface Partner {
   url: {
     type?: ('reference' | 'custom') | null;
     newTab?: boolean | null;
-    reference?: {
-      relationTo: 'pages';
-      value: string | Page;
-    } | null;
+    reference?:
+      | ({
+          relationTo: 'pages';
+          value: string | Page;
+        } | null)
+      | ({
+          relationTo: 'global-pages';
+          value: string | GlobalPage;
+        } | null);
     url?: string | null;
     label: string;
   };
@@ -665,6 +629,101 @@ export interface PartnerDetailsBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TenantSelectorBlock".
+ */
+export interface TenantSelectorBlock {
+  title: string;
+  subtitle: string;
+  ctaLabel: string;
+  emptyListLabel: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'tenant-selection';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "HeroBlock".
+ */
+export interface HeroBlock {
+  /**
+   * Displayed alongside the political entity name in the hero.
+   */
+  tagline?: string | null;
+  /**
+   * Label displayed beside the total count of synced promises.
+   */
+  promiseLabel?: string | null;
+  /**
+   * Sentence that follows the promise count, for example 'tracked on PromiseTracker'.
+   */
+  trailText?: string | null;
+  updatedAtLabel?: string | null;
+  /**
+   * Optional text that replaces the political entity position shown above the last updated date.
+   */
+  profileTitleOverride?: string | null;
+  statusListTitle?: string | null;
+  /**
+   * Define exactly three groups of promise statuses to display in the charts.
+   */
+  chartGroups: {
+    title: string;
+    statuses: (string | PromiseStatus)[];
+    id?: string | null;
+  }[];
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'hero';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "KeyPromisesBlock".
+ */
+export interface KeyPromisesBlock {
+  title: string;
+  actionLabel?: string | null;
+  /**
+   * How many highlighted promises to display (minimum 1).
+   */
+  itemsToShow: number;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'key-promises';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "LatestPromisesBlock".
+ */
+export interface LatestPromisesBlock {
+  title: string;
+  /**
+   * Link to the page where all promises can be viewed. E.g. /promises
+   */
+  seeAllLink: {
+    type?: ('reference' | 'custom') | null;
+    newTab?: boolean | null;
+    reference?:
+      | ({
+          relationTo: 'pages';
+          value: string | Page;
+        } | null)
+      | ({
+          relationTo: 'global-pages';
+          value: string | GlobalPage;
+        } | null);
+    url?: string | null;
+    label: string;
+    /**
+     * Choose how the link should be rendered.
+     */
+    appearance?: ('default' | 'outline') | null;
+  };
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'latest-promises';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "PromiseListBlock".
  */
 export interface PromiseListBlock {
@@ -676,42 +735,6 @@ export interface PromiseListBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'promise-list';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "global-pages".
- */
-export interface GlobalPage {
-  id: string;
-  title: string;
-  slug: string;
-  slugLock?: boolean | null;
-  blocks?:
-    | (
-        | ActNowBlock
-        | FAQBlock
-        | NewsletterBlock
-        | PageHeaderBlock
-        | PartnersBlock
-        | PartnerDetailsBlock
-        | TenantSelectorBlock
-      )[]
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TenantSelectorBlock".
- */
-export interface TenantSelectorBlock {
-  title: string;
-  subtitle: string;
-  ctaLabel: string;
-  emptyListLabel: string;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'tenant-selection';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -788,10 +811,15 @@ export interface SiteSetting {
           link: {
             type?: ('reference' | 'custom') | null;
             newTab?: boolean | null;
-            reference?: {
-              relationTo: 'pages';
-              value: string | Page;
-            } | null;
+            reference?:
+              | ({
+                  relationTo: 'pages';
+                  value: string | Page;
+                } | null)
+              | ({
+                  relationTo: 'global-pages';
+                  value: string | GlobalPage;
+                } | null);
             url?: string | null;
             label: string;
           };
@@ -806,10 +834,15 @@ export interface SiteSetting {
           link: {
             type?: ('reference' | 'custom') | null;
             newTab?: boolean | null;
-            reference?: {
-              relationTo: 'pages';
-              value: string | Page;
-            } | null;
+            reference?:
+              | ({
+                  relationTo: 'pages';
+                  value: string | Page;
+                } | null)
+              | ({
+                  relationTo: 'global-pages';
+                  value: string | GlobalPage;
+                } | null);
             url?: string | null;
             label: string;
           };
@@ -826,10 +859,15 @@ export interface SiteSetting {
                 link: {
                   type?: ('reference' | 'custom') | null;
                   newTab?: boolean | null;
-                  reference?: {
-                    relationTo: 'pages';
-                    value: string | Page;
-                  } | null;
+                  reference?:
+                    | ({
+                        relationTo: 'pages';
+                        value: string | Page;
+                      } | null)
+                    | ({
+                        relationTo: 'global-pages';
+                        value: string | GlobalPage;
+                      } | null);
                   url?: string | null;
                   label: string;
                 };
@@ -1405,6 +1443,13 @@ export interface GlobalPagesSelect<T extends boolean = true> {
         'partner-details'?: T | PartnerDetailsBlockSelect<T>;
         'tenant-selection'?: T | TenantSelectorBlockSelect<T>;
       };
+  meta?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+        image?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
 }
@@ -1723,10 +1768,15 @@ export interface EntityPage {
           link: {
             type?: ('reference' | 'custom') | null;
             newTab?: boolean | null;
-            reference?: {
-              relationTo: 'pages';
-              value: string | Page;
-            } | null;
+            reference?:
+              | ({
+                  relationTo: 'pages';
+                  value: string | Page;
+                } | null)
+              | ({
+                  relationTo: 'global-pages';
+                  value: string | GlobalPage;
+                } | null);
             url?: string | null;
             label: string;
           };
@@ -1743,10 +1793,15 @@ export interface EntityPage {
                 link: {
                   type?: ('reference' | 'custom') | null;
                   newTab?: boolean | null;
-                  reference?: {
-                    relationTo: 'pages';
-                    value: string | Page;
-                  } | null;
+                  reference?:
+                    | ({
+                        relationTo: 'pages';
+                        value: string | Page;
+                      } | null)
+                    | ({
+                        relationTo: 'global-pages';
+                        value: string | GlobalPage;
+                      } | null);
                   url?: string | null;
                   label: string;
                 };
@@ -1880,10 +1935,15 @@ export interface GlobalSiteSetting {
           link: {
             type?: ('reference' | 'custom') | null;
             newTab?: boolean | null;
-            reference?: {
-              relationTo: 'pages';
-              value: string | Page;
-            } | null;
+            reference?:
+              | ({
+                  relationTo: 'pages';
+                  value: string | Page;
+                } | null)
+              | ({
+                  relationTo: 'global-pages';
+                  value: string | GlobalPage;
+                } | null);
             url?: string | null;
             label: string;
           };
@@ -1898,10 +1958,15 @@ export interface GlobalSiteSetting {
           link: {
             type?: ('reference' | 'custom') | null;
             newTab?: boolean | null;
-            reference?: {
-              relationTo: 'pages';
-              value: string | Page;
-            } | null;
+            reference?:
+              | ({
+                  relationTo: 'pages';
+                  value: string | Page;
+                } | null)
+              | ({
+                  relationTo: 'global-pages';
+                  value: string | GlobalPage;
+                } | null);
             url?: string | null;
             label: string;
           };
@@ -1918,10 +1983,15 @@ export interface GlobalSiteSetting {
                 link: {
                   type?: ('reference' | 'custom') | null;
                   newTab?: boolean | null;
-                  reference?: {
-                    relationTo: 'pages';
-                    value: string | Page;
-                  } | null;
+                  reference?:
+                    | ({
+                        relationTo: 'pages';
+                        value: string | Page;
+                      } | null)
+                    | ({
+                        relationTo: 'global-pages';
+                        value: string | GlobalPage;
+                      } | null);
                   url?: string | null;
                   label: string;
                 };

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -48,7 +48,7 @@ export const plugins: Plugin[] = [
     enabled: s3Enabled,
   }),
   seoPlugin({
-    collections: ["pages", "political-entities", "promises"],
+    collections: ["pages", "political-entities", "promises", "global-pages"],
     uploadsCollection: "media",
     generateTitle: async ({ doc, collectionSlug, req }) => {
       const tenantId = doc.tenant;
@@ -68,7 +68,7 @@ export const plugins: Plugin[] = [
         return `${doc.name} - ${doc.position} | ${tenant?.name}`;
       }
 
-      if (collectionSlug === "pages") {
+      if (collectionSlug === "pages" || collectionSlug === "global-pages") {
         return `${capitalizeFirstLetter(doc.title)} | ${tenant?.name}`;
       }
 

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -6,7 +6,7 @@ export type MenuLink = {
   type?: "custom" | "reference" | null;
   url?: string | null;
   reference?: {
-    relationTo: "pages";
+    relationTo: "pages" | "global-pages";
     value: Page | string | number;
   } | null;
 };


### PR DESCRIPTION
## Description

- Extend relationTo to include "global-pages" in navigation and link types
- Add ensureUniqueGlobalPageSlug hook for global pages
- Include global-pages in SEO plugin collections
- Update payload-types with GlobalPage interface

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
