### PR TITLE
fix(payload): change query limit from -1 to 0 for all documents

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,20 +5,67 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Next.js: debug full stack",
+      "name": "Next.js: debug server",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/next/dist/bin/next",
       "runtimeArgs": ["--inspect"],
-      "skipFiles": ["<node_internals>/**"],
-      "serverReadyAction": {
-        "action": "debugWithChrome",
-        "killOnServerStop": true,
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "webRoot": "${workspaceFolder}"
+      "skipFiles": [
+        "<node_internals>/**",
+        "${workspaceFolder}/node_modules/**",
+        "**/node_modules/**"
+      ],
+      "cwd": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "webpack://_N_E/./*": "${workspaceFolder}/*",
+        "webpack://_N_E/*": "${workspaceFolder}/*",
+        "webpack:///./*": "${workspaceFolder}/*",
+        "webpack:///*": "${workspaceFolder}/*"
       },
-      "cwd": "${workspaceFolder}"
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s"
+      }
+    },
+    {
+      "name": "Next.js: debug client (default profile)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "userDataDir": false,
+      "skipFiles": ["${workspaceFolder}/node_modules/**/*.js", "**/node_modules/**/*.js"],
+      "sourceMapPathOverrides": {
+        "webpack://_N_E/./*": "${webRoot}/*",
+        "webpack://_N_E/*": "${webRoot}/*",
+        "webpack:///./*": "${webRoot}/*",
+        "webpack:///*": "${webRoot}/*"
+      }
+    },
+    {
+      "name": "Next.js: debug full stack (default profile)",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/next/dist/bin/next",
+      "runtimeArgs": ["--inspect"],
+      "skipFiles": [
+        "<node_internals>/**",
+        "${workspaceFolder}/node_modules/**",
+        "**/node_modules/**"
+      ],
+      "cwd": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "webpack://_N_E/./*": "${workspaceFolder}/*",
+        "webpack://_N_E/*": "${workspaceFolder}/*",
+        "webpack:///./*": "${workspaceFolder}/*",
+        "webpack:///*": "${workspaceFolder}/*"
+      },
+      "serverReadyAction": {
+        "action": "startDebugging",
+        "name": "Next.js: debug client (default profile)",
+        "pattern": "- Local:.+(https?://.+)"
+      }
     }
   ]
 }

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -301,7 +301,7 @@ export const Hero = async ({ entitySlug, ...block }: HeroProps) => {
 
   const { docs: statusDocs } = await payload.find({
     collection: "promise-status",
-    limit: -1,
+    limit: 0,
     depth: 0,
     locale,
   });
@@ -333,7 +333,7 @@ export const Hero = async ({ entitySlug, ...block }: HeroProps) => {
         },
       ],
     },
-    limit: -1,
+    limit: 0,
     depth: 1,
   });
 

--- a/src/components/KeyPromises/index.tsx
+++ b/src/components/KeyPromises/index.tsx
@@ -79,7 +79,7 @@ export const KeyPromises = async ({
 
   const statusQuery = await payload.find({
     collection: "promise-status",
-    limit: -1,
+    limit: 0,
     depth: 0,
     locale,
   });

--- a/src/components/PoliticalEntityList/index.tsx
+++ b/src/components/PoliticalEntityList/index.tsx
@@ -88,7 +88,7 @@ export const PoliticalEntityList = async ({
     getPromiseCountsForEntities(politicalEntities.map((entity) => entity.id)),
     payload.find({
       collection: "promise-status",
-      limit: -1,
+      limit: 0,
       depth: 0,
       locale,
     }),

--- a/src/lib/data/politicalEntities.ts
+++ b/src/lib/data/politicalEntities.ts
@@ -14,7 +14,7 @@ export const getPoliticalEntitiesByTenant = async (
 ): Promise<PoliticalEntity[]> => {
   const { docs } = await payload.find({
     collection: "political-entities",
-    limit: -1,
+    limit: 0,
     depth: 2,
     sort: "name",
     ...(locale ? { locale } : {}),
@@ -138,18 +138,16 @@ export const getPromiseCountsForEntities = async (
       continue;
     }
 
-    const summary =
-      counts[entityId] ??
-      {
-        total: 0,
-        statuses: {},
-      };
+    const summary = counts[entityId] ?? {
+      total: 0,
+      statuses: {},
+    };
 
     const statusValue = promise.status;
     let statusId =
       typeof statusValue === "string"
         ? statusValue
-        : statusValue?.id ?? statusValue?.meedanId ?? null;
+        : (statusValue?.id ?? statusValue?.meedanId ?? null);
 
     if (!statusId) {
       const publishStatus =

--- a/src/lib/data/tenants.ts
+++ b/src/lib/data/tenants.ts
@@ -15,7 +15,7 @@ export const getAllTenants = async (): Promise<
 > => {
   const { docs } = await payload.find({
     collection: "tenants",
-    limit: -1,
+    limit: 0,
     sort: "name",
   });
 

--- a/src/lib/syncMeedanReports.ts
+++ b/src/lib/syncMeedanReports.ts
@@ -149,7 +149,7 @@ export const syncMeedanReports = async ({
 
   const { docs: aiExtractionDocsRaw } = await payload.find({
     collection: "ai-extractions",
-    limit: -1,
+    limit: 0,
     depth: 2,
   });
 

--- a/src/tasks/createPoliticalEntity.ts
+++ b/src/tasks/createPoliticalEntity.ts
@@ -61,7 +61,7 @@ export const CreatePoliticalEntity: TaskConfig = {
 
       const { docs: existingEntities } = await payload.find({
         collection: "political-entities",
-        limit: -1,
+        limit: 0,
         depth: 1,
       });
 
@@ -102,7 +102,7 @@ export const CreatePoliticalEntity: TaskConfig = {
                 in: Array.from(collectDocIds),
               },
             },
-            limit: -1,
+            limit: 0,
             depth: 1,
           })
         : { docs: [] };
@@ -226,7 +226,7 @@ export const CreatePoliticalEntity: TaskConfig = {
 
       const { docs: tenantsForLookup } = await payload.find({
         collection: "tenants",
-        limit: -1,
+        limit: 0,
       });
       const tenantLookup = new Map(
         tenantsForLookup.map((tenant) => [tenant.country, tenant]),

--- a/src/tasks/fetchAirtableDocuments.ts
+++ b/src/tasks/fetchAirtableDocuments.ts
@@ -68,7 +68,7 @@ export const FetchAirtableDocuments: TaskConfig<"fetchAirtableDocuments"> = {
 
         const { docs: entities } = await payload.find({
           collection: "political-entities",
-          limit: -1,
+          limit: 0,
           depth: 2,
         });
 

--- a/src/tasks/updatePromiseStatus.ts
+++ b/src/tasks/updatePromiseStatus.ts
@@ -62,7 +62,7 @@ export const UpdatePromiseStatus: TaskConfig<"updatePromiseStatus"> = {
 
     const { docs: statusDocs } = await payload.find({
       collection: "promise-status",
-      limit: -1,
+      limit: 0,
       depth: 0,
     });
 
@@ -73,7 +73,7 @@ export const UpdatePromiseStatus: TaskConfig<"updatePromiseStatus"> = {
 
     const { docs: aiExtractions } = await payload.find({
       collection: "ai-extractions",
-      limit: -1,
+      limit: 0,
       depth: 0,
     });
 


### PR DESCRIPTION
## Description

Payload CMS uses [limit: 0](https://payloadcms.com/docs/queries/pagination#limit) to retrieve all documents, while limit: -1 is incorrect and may cause unexpected behavior. This change ensures consistent query behavior across all find operations.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
