### PR TITLE
Harden pnpm installs against supply-chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
 legacy-peer-deps=true
+block-exotic-subdeps=true
+minimum-release-age=1440
+trust-policy=no-downgrade

--- a/package.json
+++ b/package.json
@@ -105,12 +105,15 @@
     "pnpm": "^9 || ^10"
   },
   "pnpm": {
+    "blockExoticSubdeps": true,
+    "minimumReleaseAge": 1440,
     "onlyBuiltDependencies": [
       "@sentry/cli",
       "esbuild",
       "sharp",
       "unrs-resolver"
-    ]
+    ],
+    "trustPolicy": "no-downgrade"
   },
   "packageManager": "pnpm@10.16.1"
 }

--- a/package.json
+++ b/package.json
@@ -105,15 +105,12 @@
     "pnpm": "^9 || ^10"
   },
   "pnpm": {
-    "blockExoticSubdeps": true,
-    "minimumReleaseAge": 1440,
     "onlyBuiltDependencies": [
       "@sentry/cli",
       "esbuild",
       "sharp",
       "unrs-resolver"
-    ],
-    "trustPolicy": "no-downgrade"
+    ]
   },
   "packageManager": "pnpm@10.33.0"
 }

--- a/package.json
+++ b/package.json
@@ -115,5 +115,5 @@
     ],
     "trustPolicy": "no-downgrade"
   },
-  "packageManager": "pnpm@10.16.1"
+  "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
### Motivation
- Reduce supply-chain exposure during `pnpm` installs by applying the same hardening settings used in the UI repo adapted to this repository's package-level `pnpm` config.

### Description
- Added `blockExoticSubdeps: true` to the top-level `pnpm` block in `package.json` to block exotic transitive dependency sources.
- Added `minimumReleaseAge: 1440` to delay adoption of very new releases by 24 hours.
- Added `trustPolicy: "no-downgrade"` to prevent trust-regression downgrades.
- Kept the existing `onlyBuiltDependencies` allowlist (`@sentry/cli`, `esbuild`, `sharp`, `unrs-resolver`) intact.

### Testing
- Verified `package.json` parses as valid JSON with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid')"`, which succeeded.
- No additional automated test suites were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4a7915c948336ac3b852c850fd926)