### PR TITLE
chore: update export sync queue name and add cron schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate:all": "pnpm run generate:importmap && pnpm run generate:types",
     "lint": "cross-env NODE_OPTIONS=--no-deprecation next lint",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
+    "migrate": "NODE_OPTIONS=--no-deprecation payload migrate",
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:e2e",
     "test:e2e": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" pnpm exec playwright test",

--- a/src/lib/aiExtractionExportRowsJobs.ts
+++ b/src/lib/aiExtractionExportRowsJobs.ts
@@ -1,7 +1,10 @@
 import type { PayloadRequest } from "payload";
 
 export const AI_EXTRACTION_EXPORT_ROWS_SYNC_QUEUE =
-  process.env.PAYLOAD_JOBS_QUEUE || "everyMinute";
+  process.env.PAYLOAD_EXPORT_SYNC_QUEUE || "exportSync";
+
+export const AI_EXTRACTION_EXPORT_ROWS_SYNC_CRON_SCHEDULE =
+  process.env.PAYLOAD_EXPORT_SYNC_CRON_SCHEDULE || "0 * * * *";
 
 export type SyncAIExtractionExportRowsInput = {
   aiExtractionId?: string;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -17,6 +17,10 @@ import { isProd } from "@/utils/utils";
 import { plugins } from "@/plugins";
 import * as Sentry from "@sentry/nextjs";
 import { defaultLocale, locales } from "@/utils/locales";
+import {
+  AI_EXTRACTION_EXPORT_ROWS_SYNC_CRON_SCHEDULE,
+  AI_EXTRACTION_EXPORT_ROWS_SYNC_QUEUE,
+} from "@/lib/aiExtractionExportRowsJobs";
 import { en } from "@payloadcms/translations/languages/en";
 import { fr } from "@payloadcms/translations/languages/fr";
 
@@ -97,6 +101,10 @@ export default buildConfig({
       {
         cron: process.env.PAYLOAD_JOBS_CRON_SCHEDULE || "* * * * *",
         queue: process.env.PAYLOAD_JOBS_QUEUE || "everyMinute",
+      },
+      {
+        cron: AI_EXTRACTION_EXPORT_ROWS_SYNC_CRON_SCHEDULE,
+        queue: AI_EXTRACTION_EXPORT_ROWS_SYNC_QUEUE,
       },
       {
         cron: "0 * * * *",


### PR DESCRIPTION
## Description

- Change environment variable from PAYLOAD_JOBS_QUEUE to PAYLOAD_EXPORT_SYNC_QUEUE for better clarity
- Add separate cron schedule configuration via PAYLOAD_EXPORT_SYNC_CRON_SCHEDULE
- Register the export sync queue in Payload jobs configuration
- Add migrate script to package.json for database migrations
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
