### PR TITLE
feat: add RBAC and encrypted secret storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Payload
 DATABASE_URI=mongodb://127.0.0.1/your-database-name
 PAYLOAD_SECRET=YOUR_SECRET_HERE
+# Optional comma-separated list used by the roles migration. If omitted, the
+# oldest existing account becomes the initial super administrator.
+PAYLOAD_SUPER_ADMIN_EMAILS=
 AX_APACHE_TIKA_URL=http://127.0.0.1:9998/
 
 #Sentry

--- a/migrations/20260716_000000_protect_privileged_settings.ts
+++ b/migrations/20260716_000000_protect_privileged_settings.ts
@@ -1,0 +1,164 @@
+import type {
+  MigrateDownArgs,
+  MigrateUpArgs,
+  MongooseAdapter,
+} from "@payloadcms/db-mongodb";
+import type { Setting, User } from "../src/payload-types";
+import {
+  ENCRYPTED_SECRET_PREFIX,
+  isEncryptedSecret,
+} from "../src/fields/encryptedSecret";
+
+// Raw documents predate this migration, so fields the current schema
+// requires (roles, API keys) may still be missing.
+type RawUser = Partial<Pick<User, "email" | "roles">>;
+
+type RawSettings = {
+  airtable?: Partial<Setting["airtable"]>;
+  ai?: Partial<Pick<Setting["ai"], "apiKey" | "providerCredentials">>;
+  meedan?: Partial<Setting["meedan"]>;
+};
+
+const encryptValue = (
+  value: string | null | undefined,
+  encrypt: (value: string) => string,
+): string | null | undefined => {
+  if (!value || isEncryptedSecret(value)) {
+    return value;
+  }
+
+  return `${ENCRYPTED_SECRET_PREFIX}${encrypt(value)}`;
+};
+
+const decryptValue = (
+  value: string | null | undefined,
+  decrypt: (value: string) => string,
+): string | null | undefined => {
+  if (!isEncryptedSecret(value)) {
+    return value;
+  }
+
+  return decrypt(value.slice(ENCRYPTED_SECRET_PREFIX.length));
+};
+
+const transformSettingsSecrets = (
+  settings: RawSettings,
+  transform: (value: string | null | undefined) => string | null | undefined,
+) => {
+  const providerCredentials = settings.ai?.providerCredentials?.map(
+    (credential) => ({
+      ...credential,
+      apiKey: transform(credential.apiKey),
+    }),
+  );
+
+  return {
+    "airtable.airtableAPIKey": transform(
+      settings.airtable?.airtableAPIKey,
+    ),
+    "ai.apiKey": transform(settings.ai?.apiKey),
+    "ai.providerCredentials": providerCredentials,
+    "meedan.meedanAPIKey": transform(settings.meedan?.meedanAPIKey),
+  };
+};
+
+export async function up({ payload }: MigrateUpArgs): Promise<void> {
+  const db = payload.db as MongooseAdapter;
+  const usersModel = db.collections.users;
+  // All globals share a single collection, discriminated by `globalType`.
+  const globalsModel = db.globals;
+
+  if (!usersModel || !globalsModel) {
+    throw new Error("Failed to resolve users or globals models");
+  }
+
+  // `_id` keeps the driver's ObjectId type; only the fields we read are
+  // narrowed to the generated User shape.
+  const users = (
+    await usersModel.collection
+      .find({})
+      .sort({ createdAt: 1, _id: 1 })
+      .toArray()
+  ).map((doc) => ({ ...(doc as RawUser), _id: doc._id }));
+
+  const configuredSuperAdmins = new Set(
+    (process.env.PAYLOAD_SUPER_ADMIN_EMAILS ?? "")
+      .split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  let hasSuperAdmin = users.some((user) =>
+    user.roles?.includes("superAdmin"),
+  );
+
+  for (const [index, user] of users.entries()) {
+    if (Array.isArray(user.roles) && user.roles.length > 0) {
+      continue;
+    }
+
+    const configured =
+      typeof user.email === "string" &&
+      configuredSuperAdmins.has(user.email.toLowerCase());
+    const roles =
+      configured || (!hasSuperAdmin && index === 0)
+        ? ["superAdmin"]
+        : ["globalEditor"];
+
+    if (roles.includes("superAdmin")) {
+      hasSuperAdmin = true;
+    }
+
+    await usersModel.collection.updateOne(
+      { _id: user._id },
+      { $set: { roles } },
+    );
+  }
+
+  const settingsDoc = await globalsModel.collection.findOne({
+    globalType: "settings",
+  });
+
+  if (settingsDoc) {
+    await globalsModel.collection.updateOne(
+      { _id: settingsDoc._id },
+      {
+        $set: transformSettingsSecrets(settingsDoc as RawSettings, (value) =>
+          encryptValue(value, (secret) => payload.encrypt(secret)),
+        ),
+      },
+    );
+  }
+
+  payload.logger.info({
+    msg: "protectPrivilegedSettings:: Assigned user roles and encrypted saved credentials",
+    usersProcessed: users.length,
+  });
+}
+
+export async function down({ payload }: MigrateDownArgs): Promise<void> {
+  const db = payload.db as MongooseAdapter;
+  const usersModel = db.collections.users;
+  const globalsModel = db.globals;
+
+  if (!usersModel || !globalsModel) {
+    throw new Error("Failed to resolve users or globals models");
+  }
+
+  const settingsDoc = await globalsModel.collection.findOne({
+    globalType: "settings",
+  });
+
+  if (settingsDoc) {
+    await globalsModel.collection.updateOne(
+      { _id: settingsDoc._id },
+      {
+        $set: transformSettingsSecrets(settingsDoc as RawSettings, (value) =>
+          decryptValue(value, (secret) => payload.decrypt(secret)),
+        ),
+      },
+    );
+  }
+
+  await usersModel.collection.updateMany({}, { $unset: { roles: "" } });
+}

--- a/src/access/roles.ts
+++ b/src/access/roles.ts
@@ -1,0 +1,46 @@
+import type { Access, CollectionConfig, FieldAccess } from "payload";
+import { User } from "@/payload-types";
+
+export const USER_ROLES = ["superAdmin", "globalEditor"] as const;
+
+export type UserRole = (typeof USER_ROLES)[number];
+
+type CollectionAdminAccess = NonNullable<
+  NonNullable<CollectionConfig["access"]>["admin"]
+>;
+
+type CollectionHidden = Exclude<
+  NonNullable<CollectionConfig["admin"]>["hidden"],
+  boolean | undefined
+>;
+
+export const isSuperAdmin = (
+  user: Pick<User, "roles"> | null | undefined,
+): boolean => Boolean(user?.roles?.includes("superAdmin"));
+
+export const authenticated: CollectionAdminAccess = ({ req }) =>
+  Boolean(req.user);
+
+export const superAdmins: Access = ({ req }) => isSuperAdmin(req.user);
+
+export const superAdminsOrSelf: Access = ({ req }) => {
+  if (isSuperAdmin(req.user)) {
+    return true;
+  }
+
+  if (req.user) {
+    return {
+      id: {
+        equals: req.user.id,
+      },
+    };
+  }
+
+  return false;
+};
+
+export const superAdminFieldAccess: FieldAccess = ({ req }) =>
+  isSuperAdmin(req.user);
+
+export const shouldHideFromNonSuperAdmins: CollectionHidden = ({ user }) =>
+  !isSuperAdmin({ roles: user.roles });

--- a/src/collections/Users/hooks/index.ts
+++ b/src/collections/Users/hooks/index.ts
@@ -1,0 +1,32 @@
+import { CollectionBeforeValidateHook } from "payload";
+
+export const assignInitialRole: CollectionBeforeValidateHook = async ({
+  data,
+  operation,
+  req,
+}) => {
+  if (operation !== "create") {
+    return data;
+  }
+
+  const { totalDocs } = await req.payload.count({
+    collection: "users",
+    overrideAccess: true,
+    req,
+  });
+
+  if (totalDocs === 0) {
+    return {
+      ...data,
+      roles: ["superAdmin"],
+    };
+  }
+
+  return {
+    ...data,
+    roles:
+      Array.isArray(data?.roles) && data.roles.length > 0
+        ? data.roles
+        : ["globalEditor"],
+  };
+};

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -1,7 +1,23 @@
+import {
+  authenticated,
+  shouldHideFromNonSuperAdmins,
+  superAdminFieldAccess,
+  superAdmins,
+  superAdminsOrSelf,
+} from "@/access/roles";
 import type { CollectionConfig } from "payload";
+import { assignInitialRole } from "./hooks";
 
 export const Users: CollectionConfig = {
   slug: "users",
+  access: {
+    admin: authenticated,
+    create: superAdmins,
+    delete: superAdmins,
+    read: superAdminsOrSelf,
+    unlock: superAdmins,
+    update: superAdminsOrSelf,
+  },
   labels: {
     singular: {
       en: "User",
@@ -14,11 +30,52 @@ export const Users: CollectionConfig = {
   },
   admin: {
     useAsTitle: "email",
+    hidden: shouldHideFromNonSuperAdmins,
     group: {
       en: "Settings",
       fr: "Paramètres",
     },
   },
   auth: true,
-  fields: [],
+  fields: [
+    {
+      name: "roles",
+      type: "select",
+      hasMany: true,
+      required: true,
+      defaultValue: ["globalEditor"],
+      saveToJWT: true,
+      access: {
+        create: superAdminFieldAccess,
+        read: superAdminFieldAccess,
+        update: superAdminFieldAccess,
+      },
+      admin: {
+        position: "sidebar",
+      },
+      label: {
+        en: "Roles",
+        fr: "Rôles",
+      },
+      options: [
+        {
+          label: {
+            en: "Super administrator",
+            fr: "Super administrateur",
+          },
+          value: "superAdmin",
+        },
+        {
+          label: {
+            en: "Global editor",
+            fr: "Éditeur global",
+          },
+          value: "globalEditor",
+        },
+      ],
+    },
+  ],
+  hooks: {
+    beforeValidate: [assignInitialRole],
+  },
 };

--- a/src/fields/encryptedSecret.ts
+++ b/src/fields/encryptedSecret.ts
@@ -1,0 +1,67 @@
+import { superAdminFieldAccess } from "@/access/roles";
+import type { FieldHook, TextField } from "payload";
+
+export const ENCRYPTED_SECRET_PREFIX = "enc:v1:";
+export const REDACTED_SECRET_VALUE = "********";
+
+export const isEncryptedSecret = (value: unknown): value is string =>
+  typeof value === "string" && value.startsWith(ENCRYPTED_SECRET_PREFIX);
+
+export const encryptSecretValue: FieldHook = ({
+  previousValue,
+  req,
+  value,
+}) => {
+  if (value === REDACTED_SECRET_VALUE) {
+    return previousValue;
+  }
+
+  if (typeof value !== "string" || value.length === 0) {
+    return value;
+  }
+
+  if (isEncryptedSecret(value)) {
+    return value;
+  }
+
+  return `${ENCRYPTED_SECRET_PREFIX}${req.payload.encrypt(value)}`;
+};
+
+export const readSecretValue: FieldHook = ({ req, value }) => {
+  if (typeof value !== "string" || value.length === 0) {
+    return value;
+  }
+
+  if (req.payloadAPI !== "local") {
+    return REDACTED_SECRET_VALUE;
+  }
+
+  if (!isEncryptedSecret(value)) {
+    // Supports existing plaintext values until the data migration is applied.
+    return value;
+  }
+
+  return req.payload.decrypt(value.slice(ENCRYPTED_SECRET_PREFIX.length));
+};
+
+type SingleTextField = Extract<TextField, { hasMany?: false | undefined }>;
+
+export const encryptedSecretField = (
+  field: Omit<SingleTextField, "hooks" | "type"> & {
+    hooks?: SingleTextField["hooks"];
+  },
+): TextField => ({
+  ...field,
+  type: "text",
+  access: {
+    ...field.access,
+    create: superAdminFieldAccess,
+    read: superAdminFieldAccess,
+    update: superAdminFieldAccess,
+  },
+  hooks: {
+    ...field.hooks,
+    afterRead: [...(field.hooks?.afterRead ?? []), readSecretValue],
+    beforeChange: [...(field.hooks?.beforeChange ?? []), encryptSecretValue],
+  },
+});

--- a/src/globals/Settings/index.ts
+++ b/src/globals/Settings/index.ts
@@ -2,6 +2,7 @@ import { GlobalConfig } from "payload";
 import { AITab } from "./tabs/AITab";
 import { AirtableTab } from "./tabs/AirtableTab";
 import { MeedanTab } from "./tabs/MeedanTab";
+import { superAdmins } from "@/access/roles";
 
 export const Settings: GlobalConfig = {
   slug: "settings",
@@ -10,8 +11,8 @@ export const Settings: GlobalConfig = {
     fr: "Paramètres",
   },
   access: {
-    read: ({ req }) => Boolean(req.user),
-    update: ({ req }) => Boolean(req.user),
+    read: superAdmins,
+    update: superAdmins,
   },
   admin: {
     group: {

--- a/src/globals/Settings/tabs/AITab.ts
+++ b/src/globals/Settings/tabs/AITab.ts
@@ -12,6 +12,7 @@ import {
 import { validateProviderApiKey } from "@/lib/ai/providerCredentialValidation";
 import { trimToUndefined } from "@/lib/ai/stringUtils";
 import type { Tab } from "payload";
+import { encryptedSecretField } from "@/fields/encryptedSecret";
 
 type AIProviderCredentialRow = {
   provider?: string | null;
@@ -483,9 +484,8 @@ export const AITab: Tab = {
                   },
                   options: AI_PROVIDER_OPTIONS,
                 },
-                {
+                encryptedSecretField({
                   name: "apiKey",
-                  type: "text",
                   label: {
                     en: "API Key",
                     fr: "Clé API",
@@ -499,7 +499,7 @@ export const AITab: Tab = {
                     },
                   },
                   validate: validateProviderCredentialApiKey,
-                },
+                }),
                 {
                   name: "baseURL",
                   type: "text",
@@ -621,17 +621,16 @@ export const AITab: Tab = {
             condition: () => false,
           },
         },
-        {
+        encryptedSecretField({
           name: "apiKey",
           label: {
             en: "Legacy API Key (Deprecated)",
             fr: "Clé API héritée (dépréciée)",
           },
-          type: "text",
           admin: {
             condition: () => false,
           },
-        },
+        }),
       ],
     },
   ],

--- a/src/globals/Settings/tabs/AirtableTab.ts
+++ b/src/globals/Settings/tabs/AirtableTab.ts
@@ -1,4 +1,5 @@
 import type { Tab } from "payload";
+import { encryptedSecretField } from "@/fields/encryptedSecret";
 
 export const AirtableTab: Tab = {
   label: {
@@ -17,13 +18,12 @@ export const AirtableTab: Tab = {
         {
           type: "row",
           fields: [
-            {
+            encryptedSecretField({
               name: "airtableAPIKey",
               label: {
                 en: "Airtable API Key",
                 fr: "Clé API Airtable",
               },
-              type: "text",
               required: true,
               admin: {
                 components: {
@@ -31,7 +31,7 @@ export const AirtableTab: Tab = {
                     "@/globals/Settings/tabs/MaskedApiKeyField#MaskedApiKeyField",
                 },
               },
-            },
+            }),
             {
               name: "airtableBaseID",
               label: {

--- a/src/globals/Settings/tabs/MaskedApiKeyField.tsx
+++ b/src/globals/Settings/tabs/MaskedApiKeyField.tsx
@@ -57,8 +57,11 @@ export const MaskedApiKeyField: React.FC<TextFieldClientProps> = (props) => {
     typeof props.field.admin?.description === "string"
       ? props.field.admin.description
       : "";
-  const previewDescription = maskedPreview
-    ? `Saved value preview: ${maskedPreview}`
+  const hasSavedSecret = fieldValue === "********";
+  const previewDescription = hasSavedSecret
+    ? "A saved secret is configured. Enter a new value to replace it."
+    : maskedPreview
+      ? `New value preview: ${maskedPreview}`
     : "Value preview appears after you enter an API key.";
   const combinedDescription = `${staticDescription} ${previewDescription}`.trim();
 

--- a/src/globals/Settings/tabs/MeedanTab.ts
+++ b/src/globals/Settings/tabs/MeedanTab.ts
@@ -1,4 +1,5 @@
 import type { Tab } from "payload";
+import { encryptedSecretField } from "@/fields/encryptedSecret";
 
 export const MeedanTab: Tab = {
   label: {
@@ -17,9 +18,8 @@ export const MeedanTab: Tab = {
         {
           type: "row",
           fields: [
-            {
+            encryptedSecretField({
               name: "meedanAPIKey",
-              type: "text",
               required: true,
               label: {
                 en: "Meedan API Key",
@@ -31,7 +31,7 @@ export const MeedanTab: Tab = {
                     "@/globals/Settings/tabs/MaskedApiKeyField#MaskedApiKeyField",
                 },
               },
-            },
+            }),
             {
               name: "teamId",
               type: "text",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -805,6 +805,7 @@ export interface PromiseListBlock {
  */
 export interface User {
   id: string;
+  roles: ('superAdmin' | 'globalEditor')[];
   tenants?:
     | {
         tenant: string | Tenant;
@@ -1681,6 +1682,7 @@ export interface TenantSelectorBlockSelect<T extends boolean = true> {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  roles?: T;
   tenants?:
     | T
     | {

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -74,6 +74,9 @@ export default buildConfig({
     url: process.env.DATABASE_URI || "",
   }),
   editor: lexicalEditor(),
+  graphQL: {
+    disable: true,
+  },
   email,
   globals,
   hooks: {

--- a/tests/int/privilegedAccess.int.spec.ts
+++ b/tests/int/privilegedAccess.int.spec.ts
@@ -1,0 +1,151 @@
+import { isSuperAdmin, superAdmins } from "@/access/roles";
+import { Users } from "@/collections/Users";
+import {
+  ENCRYPTED_SECRET_PREFIX,
+  REDACTED_SECRET_VALUE,
+  encryptSecretValue,
+  readSecretValue,
+} from "@/fields/encryptedSecret";
+import { Settings } from "@/globals/Settings";
+import type { User } from "@/payload-types";
+import type { PayloadRequest } from "payload";
+import { describe, expect, it, vi } from "vitest";
+
+const superAdmin: Pick<User, "id" | "roles"> = {
+  id: "super-admin",
+  roles: ["superAdmin"],
+};
+const globalEditor: Pick<User, "id" | "roles"> = {
+  id: "global-editor",
+  roles: ["globalEditor"],
+};
+
+const accessArgs = (
+  user: typeof globalEditor | typeof superAdmin | null,
+  payloadAPI: PayloadRequest["payloadAPI"],
+) =>
+  ({
+    req: {
+      payloadAPI,
+      user,
+    },
+  }) as never;
+
+describe("privileged access", () => {
+  it("recognizes only the superAdmin role as privileged", () => {
+    expect(isSuperAdmin(superAdmin)).toBe(true);
+    expect(isSuperAdmin(globalEditor)).toBe(false);
+    expect(isSuperAdmin({ roles: [] })).toBe(false);
+    expect(isSuperAdmin(null)).toBe(false);
+  });
+
+  it.each(["REST", "GraphQL"] as const)(
+    "denies %s user and settings access to global editors",
+    async (payloadAPI) => {
+      expect(
+        await Users.access?.create?.(accessArgs(globalEditor, payloadAPI)),
+      ).toBe(false);
+      expect(
+        await Users.access?.delete?.(accessArgs(globalEditor, payloadAPI)),
+      ).toBe(false);
+      expect(
+        await Settings.access?.read?.(accessArgs(globalEditor, payloadAPI)),
+      ).toBe(false);
+      expect(
+        await Settings.access?.update?.(accessArgs(globalEditor, payloadAPI)),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["REST", "GraphQL"] as const)(
+    "limits %s global editors to viewing and updating their own account",
+    async (payloadAPI) => {
+      const selfFilter = { id: { equals: globalEditor.id } };
+
+      expect(
+        await Users.access?.read?.(accessArgs(globalEditor, payloadAPI)),
+      ).toEqual(selfFilter);
+      expect(
+        await Users.access?.update?.(accessArgs(globalEditor, payloadAPI)),
+      ).toEqual(selfFilter);
+    },
+  );
+
+  it.each(["REST", "GraphQL"] as const)(
+    "denies %s account access to anonymous users",
+    async (payloadAPI) => {
+      expect(await Users.access?.read?.(accessArgs(null, payloadAPI))).toBe(
+        false,
+      );
+      expect(await Users.access?.update?.(accessArgs(null, payloadAPI))).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each(["REST", "GraphQL"] as const)(
+    "allows %s user and settings access to super administrators",
+    async (payloadAPI) => {
+      expect(await superAdmins(accessArgs(superAdmin, payloadAPI))).toBe(true);
+      expect(
+        await Users.access?.read?.(accessArgs(superAdmin, payloadAPI)),
+      ).toBe(true);
+      expect(
+        await Settings.access?.read?.(accessArgs(superAdmin, payloadAPI)),
+      ).toBe(true);
+      expect(
+        await Settings.access?.update?.(accessArgs(superAdmin, payloadAPI)),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("encrypted credential fields", () => {
+  const encrypted = `${ENCRYPTED_SECRET_PREFIX}ciphertext`;
+  const payload = {
+    decrypt: vi.fn(() => "plain-secret"),
+    encrypt: vi.fn(() => "ciphertext"),
+  };
+
+  it("encrypts new values before persistence", async () => {
+    const result = await encryptSecretValue({
+      req: { payload },
+      value: "plain-secret",
+    } as never);
+
+    expect(result).toBe(encrypted);
+    expect(payload.encrypt).toHaveBeenCalledWith("plain-secret");
+  });
+
+  it("preserves the encrypted value when a redacted form is saved", async () => {
+    const result = await encryptSecretValue({
+      previousValue: encrypted,
+      req: { payload },
+      value: REDACTED_SECRET_VALUE,
+    } as never);
+
+    expect(result).toBe(encrypted);
+  });
+
+  it.each(["REST", "GraphQL"] as const)(
+    "never returns plaintext through %s",
+    async (payloadAPI) => {
+      const result = await readSecretValue({
+        req: { payload, payloadAPI },
+        value: encrypted,
+      } as never);
+
+      expect(result).toBe(REDACTED_SECRET_VALUE);
+    },
+  );
+
+  it("decrypts values for trusted Local API jobs", async () => {
+    const result = await readSecretValue({
+      req: { payload, payloadAPI: "local" },
+      value: encrypted,
+    } as never);
+
+    expect(result).toBe("plain-secret");
+    expect(payload.decrypt).toHaveBeenCalledWith("ciphertext");
+  });
+});

--- a/tests/int/privilegedAccess.int.spec.ts
+++ b/tests/int/privilegedAccess.int.spec.ts
@@ -8,7 +8,6 @@ import {
 } from "@/fields/encryptedSecret";
 import { Settings } from "@/globals/Settings";
 import type { User } from "@/payload-types";
-import type { PayloadRequest } from "payload";
 import { describe, expect, it, vi } from "vitest";
 
 const superAdmin: Pick<User, "id" | "roles"> = {
@@ -20,13 +19,10 @@ const globalEditor: Pick<User, "id" | "roles"> = {
   roles: ["globalEditor"],
 };
 
-const accessArgs = (
-  user: typeof globalEditor | typeof superAdmin | null,
-  payloadAPI: PayloadRequest["payloadAPI"],
-) =>
+const accessArgs = (user: typeof globalEditor | typeof superAdmin | null) =>
   ({
     req: {
-      payloadAPI,
+      payloadAPI: "REST",
       user,
     },
   }) as never;
@@ -39,65 +35,37 @@ describe("privileged access", () => {
     expect(isSuperAdmin(null)).toBe(false);
   });
 
-  it.each(["REST", "GraphQL"] as const)(
-    "denies %s user and settings access to global editors",
-    async (payloadAPI) => {
-      expect(
-        await Users.access?.create?.(accessArgs(globalEditor, payloadAPI)),
-      ).toBe(false);
-      expect(
-        await Users.access?.delete?.(accessArgs(globalEditor, payloadAPI)),
-      ).toBe(false);
-      expect(
-        await Settings.access?.read?.(accessArgs(globalEditor, payloadAPI)),
-      ).toBe(false);
-      expect(
-        await Settings.access?.update?.(accessArgs(globalEditor, payloadAPI)),
-      ).toBe(false);
-    },
-  );
+  it("denies user and settings administration to global editors", async () => {
+    expect(await Users.access?.create?.(accessArgs(globalEditor))).toBe(false);
+    expect(await Users.access?.delete?.(accessArgs(globalEditor))).toBe(false);
+    expect(await Settings.access?.read?.(accessArgs(globalEditor))).toBe(false);
+    expect(await Settings.access?.update?.(accessArgs(globalEditor))).toBe(
+      false,
+    );
+  });
 
-  it.each(["REST", "GraphQL"] as const)(
-    "limits %s global editors to viewing and updating their own account",
-    async (payloadAPI) => {
-      const selfFilter = { id: { equals: globalEditor.id } };
+  it("limits global editors to viewing and updating their own account", async () => {
+    const selfFilter = { id: { equals: globalEditor.id } };
 
-      expect(
-        await Users.access?.read?.(accessArgs(globalEditor, payloadAPI)),
-      ).toEqual(selfFilter);
-      expect(
-        await Users.access?.update?.(accessArgs(globalEditor, payloadAPI)),
-      ).toEqual(selfFilter);
-    },
-  );
+    expect(await Users.access?.read?.(accessArgs(globalEditor))).toEqual(
+      selfFilter,
+    );
+    expect(await Users.access?.update?.(accessArgs(globalEditor))).toEqual(
+      selfFilter,
+    );
+  });
 
-  it.each(["REST", "GraphQL"] as const)(
-    "denies %s account access to anonymous users",
-    async (payloadAPI) => {
-      expect(await Users.access?.read?.(accessArgs(null, payloadAPI))).toBe(
-        false,
-      );
-      expect(await Users.access?.update?.(accessArgs(null, payloadAPI))).toBe(
-        false,
-      );
-    },
-  );
+  it("denies account access to anonymous users", async () => {
+    expect(await Users.access?.read?.(accessArgs(null))).toBe(false);
+    expect(await Users.access?.update?.(accessArgs(null))).toBe(false);
+  });
 
-  it.each(["REST", "GraphQL"] as const)(
-    "allows %s user and settings access to super administrators",
-    async (payloadAPI) => {
-      expect(await superAdmins(accessArgs(superAdmin, payloadAPI))).toBe(true);
-      expect(
-        await Users.access?.read?.(accessArgs(superAdmin, payloadAPI)),
-      ).toBe(true);
-      expect(
-        await Settings.access?.read?.(accessArgs(superAdmin, payloadAPI)),
-      ).toBe(true);
-      expect(
-        await Settings.access?.update?.(accessArgs(superAdmin, payloadAPI)),
-      ).toBe(true);
-    },
-  );
+  it("allows user and settings access to super administrators", async () => {
+    expect(await superAdmins(accessArgs(superAdmin))).toBe(true);
+    expect(await Users.access?.read?.(accessArgs(superAdmin))).toBe(true);
+    expect(await Settings.access?.read?.(accessArgs(superAdmin))).toBe(true);
+    expect(await Settings.access?.update?.(accessArgs(superAdmin))).toBe(true);
+  });
 });
 
 describe("encrypted credential fields", () => {
@@ -127,17 +95,14 @@ describe("encrypted credential fields", () => {
     expect(result).toBe(encrypted);
   });
 
-  it.each(["REST", "GraphQL"] as const)(
-    "never returns plaintext through %s",
-    async (payloadAPI) => {
-      const result = await readSecretValue({
-        req: { payload, payloadAPI },
-        value: encrypted,
-      } as never);
+  it("never returns plaintext through the REST API", async () => {
+    const result = await readSecretValue({
+      req: { payload, payloadAPI: "REST" },
+      value: encrypted,
+    } as never);
 
-      expect(result).toBe(REDACTED_SECRET_VALUE);
-    },
-  );
+    expect(result).toBe(REDACTED_SECRET_VALUE);
+  });
 
   it("decrypts values for trusted Local API jobs", async () => {
     const result = await readSecretValue({


### PR DESCRIPTION
## Description

- implement role-based access control with superAdmin and globalEditor roles
- add encrypted secret field type for secure storage of third-party API keys
- restrict Settings global and Users collection access to authorized admins
- disable GraphQL API to reduce application attack surface
- add database migration for initial user role assignment and secret encryption
- add test coverage for access control logic and encrypted field handling
- update environment variable example for super admin email configuration
- refactor API key fields across AI, Airtable, and Meedan settings to use encrypted storage

Fixes #579 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
