### PR TITLE
fix(types): move resolveBrowserLocale out of layout into src/lib/locale

### DIFF
--- a/src/app/(frontend)/[...slugs]/page.tsx
+++ b/src/app/(frontend)/[...slugs]/page.tsx
@@ -21,7 +21,7 @@ import {
   resolveTenantSeoContext,
 } from "@/lib/seo";
 import { resolveTenantLocale } from "@/utils/locales";
-import { resolveBrowserLocale } from "../layout";
+import { resolveBrowserLocale } from "@/lib/locale";
 import type { EntityPage } from "@/payload-types";
 import type { MenuLink } from "@/types/navigation";
 

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -4,14 +4,10 @@ import theme from "@/theme/theme";
 import { ThemeProvider } from "@mui/material";
 import { Inter } from "next/font/google";
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { getDomain } from "@/lib/domain";
+import { resolveBrowserLocale } from "@/lib/locale";
 import { getTenantBySubDomain } from "@/lib/data/tenants";
-import {
-  PAYLOAD_SUPPORTED_LOCALES,
-  type PayloadLocale,
-  resolveTenantLocale,
-} from "@/utils/locales";
+import { resolveTenantLocale } from "@/utils/locales";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -27,34 +23,6 @@ export const metadata: Metadata = {
     icon: "/favicon.ico",
     shortcut: "/favicon.ico",
   },
-};
-
-export const resolveBrowserLocale = async (): Promise<PayloadLocale> => {
-  const headerList = await headers();
-  const acceptLanguage = headerList.get("accept-language");
-  if (!acceptLanguage) {
-    return "en";
-  }
-
-  const supported = new Set<PayloadLocale>(PAYLOAD_SUPPORTED_LOCALES);
-  const candidates = acceptLanguage
-    .split(",")
-    .map((entry) => entry.trim().split(";")[0]?.toLowerCase())
-    .filter(Boolean);
-
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    if (supported.has(candidate as PayloadLocale)) {
-      return candidate as PayloadLocale;
-    }
-
-    const [base] = candidate.split("-");
-    if (base && supported.has(base as PayloadLocale)) {
-      return base as PayloadLocale;
-    }
-  }
-
-  return "en";
 };
 
 export default async function RootLayout(props: { children: React.ReactNode }) {

--- a/src/components/KeyPromises/index.tsx
+++ b/src/components/KeyPromises/index.tsx
@@ -1,4 +1,4 @@
-import { resolveBrowserLocale } from "@/app/(frontend)/layout";
+import { resolveBrowserLocale } from "@/lib/locale";
 import { resolveMedia } from "@/lib/data/media";
 import { getPromiseUpdateEmbed } from "@/lib/data/promiseUpdates";
 import { getTenantBySubDomain } from "@/lib/data/tenants";

--- a/src/components/LatestPromises/index.tsx
+++ b/src/components/LatestPromises/index.tsx
@@ -6,7 +6,7 @@ import { getPromiseUpdateEmbed } from "@/lib/data/promiseUpdates";
 import { getTenantBySubDomain } from "@/lib/data/tenants";
 import { getDomain } from "@/lib/domain";
 import { resolveTenantLocale } from "@/utils/locales";
-import { resolveBrowserLocale } from "@/app/(frontend)/layout";
+import { resolveBrowserLocale } from "@/lib/locale";
 
 export type LatestPromisesProps = LatestPromisesBlock & {
   entitySlug: string;

--- a/src/components/Newsletter/Newsletter.tsx
+++ b/src/components/Newsletter/Newsletter.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@/payload-types";
 import { getGlobalPayload } from "@/lib/payload";
 import { resolveTenantLocale } from "@/utils/locales";
-import { resolveBrowserLocale } from "@/app/(frontend)/layout";
+import { resolveBrowserLocale } from "@/lib/locale";
 
 const payload = await getGlobalPayload();
 

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -1,0 +1,33 @@
+import { headers } from "next/headers";
+import {
+  PAYLOAD_SUPPORTED_LOCALES,
+  type PayloadLocale,
+} from "@/utils/locales";
+
+export const resolveBrowserLocale = async (): Promise<PayloadLocale> => {
+  const headerList = await headers();
+  const acceptLanguage = headerList.get("accept-language");
+  if (!acceptLanguage) {
+    return "en";
+  }
+
+  const supported = new Set<PayloadLocale>(PAYLOAD_SUPPORTED_LOCALES);
+  const candidates = acceptLanguage
+    .split(",")
+    .map((entry) => entry.trim().split(";")[0]?.toLowerCase())
+    .filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (supported.has(candidate as PayloadLocale)) {
+      return candidate as PayloadLocale;
+    }
+
+    const [base] = candidate.split("-");
+    if (base && supported.has(base as PayloadLocale)) {
+      return base as PayloadLocale;
+    }
+  }
+
+  return "en";
+};


### PR DESCRIPTION
## Summary

`pnpm exec tsc --noEmit` was failing with one error from the generated `.next/types/app/(frontend)/layout.ts`: Next.js typed routes forbid extra exports from layout files, and `src/app/(frontend)/layout.tsx` exported `resolveBrowserLocale`.

- Move `resolveBrowserLocale` (verbatim) into a new server-side module `src/lib/locale.ts`, following the pattern of `src/lib/domain.ts` (which also uses `next/headers`)
- Update all importers to use `@/lib/locale`: the `(frontend)` layout, `[...slugs]/page.tsx`, `LatestPromises`, `KeyPromises`, and `Newsletter`
- Drop the layout's now-unused `headers` and `PAYLOAD_SUPPORTED_LOCALES`/`PayloadLocale` imports


## Test plan

- `pnpm exec tsc --noEmit` passes (exit 0), including against the generated per-file typed-routes validator that raised the original error
- `eslint` clean on all touched files
