### PR TITLE
feat(access): add access controls for public reads

### DIFF
--- a/src/access/roles.ts
+++ b/src/access/roles.ts
@@ -21,6 +21,11 @@ export const isSuperAdmin = (
 export const authenticated: CollectionAdminAccess = ({ req }) =>
   Boolean(req.user);
 
+export const authenticatedUsers: Access = ({ req }) => Boolean(req.user);
+
+export const authenticatedFieldAccess: FieldAccess = ({ req }) =>
+  Boolean(req.user);
+
 export const superAdmins: Access = ({ req }) => isSuperAdmin(req.user);
 
 export const superAdminsOrSelf: Access = ({ req }) => {

--- a/src/collections/AIExtractions/index.ts
+++ b/src/collections/AIExtractions/index.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload";
+import { authenticatedUsers } from "@/access/roles";
 import {
   deleteAIExtractionExportRowsAfterAIExtractionDelete,
   queueAIExtractionExportRowsSyncAfterAIExtractionChange,
@@ -23,8 +24,10 @@ export const AIExtractions: CollectionConfig = {
     },
     useAsTitle: "title",
   },
+  // Extraction records expose internal pipeline state (CheckMedia IDs,
+  // upload errors, raw extractions) and are not public presentation content.
   access: {
-    read: () => true,
+    read: authenticatedUsers,
   },
   hooks: {
     afterChange: [queueAIExtractionExportRowsSyncAfterAIExtractionChange],

--- a/src/collections/Documents/index.ts
+++ b/src/collections/Documents/index.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload";
+import { authenticatedUsers } from "@/access/roles";
 import { airtableID } from "@/fields/airtableID";
 import {
   deleteAIExtractionExportRowsAfterDocumentDelete,
@@ -17,8 +18,10 @@ export const Documents: CollectionConfig = {
       fr: "Documents",
     },
   },
+  // Source documents carry internal processing data (extracted text, source
+  // URLs, sync metadata) and are not public presentation content.
   access: {
-    read: () => true,
+    read: authenticatedUsers,
   },
   hooks: {
     afterChange: [queueAIExtractionExportRowsSyncAfterDocumentChange],

--- a/src/collections/Promises.ts
+++ b/src/collections/Promises.ts
@@ -1,5 +1,19 @@
-import { CollectionConfig } from "payload";
+import { Access, CollectionConfig } from "payload";
+import { authenticatedFieldAccess } from "@/access/roles";
 import { image as imageField } from "@/fields/image";
+
+// Anonymous visitors only ever see published promises; editors see drafts too.
+const publishedOrAuthenticated: Access = ({ req }) => {
+  if (req.user) {
+    return true;
+  }
+
+  return {
+    publishStatus: {
+      equals: "published",
+    },
+  };
+};
 
 export const Promises: CollectionConfig = {
   slug: "promises",
@@ -22,7 +36,7 @@ export const Promises: CollectionConfig = {
     defaultColumns: ["title", "status", "politicalEntity", "url"],
   },
   access: {
-    read: () => true,
+    read: publishedOrAuthenticated,
   },
   fields: [
     {
@@ -30,6 +44,10 @@ export const Promises: CollectionConfig = {
       type: "text",
       required: true,
       unique: true,
+      // External-system identifier; not part of the public presentation data.
+      access: {
+        read: authenticatedFieldAccess,
+      },
       label: {
         en: "Meedan ID",
         fr: "ID Meedan",

--- a/tests/int/publicApiAccess.int.spec.ts
+++ b/tests/int/publicApiAccess.int.spec.ts
@@ -1,0 +1,57 @@
+import { AIExtractions } from "@/collections/AIExtractions";
+import { Documents } from "@/collections/Documents";
+import { Promises } from "@/collections/Promises";
+import type { User } from "@/payload-types";
+import type { Field, TextField } from "payload";
+import { describe, expect, it } from "vitest";
+
+const editor: Pick<User, "id" | "roles"> = {
+  id: "global-editor",
+  roles: ["globalEditor"],
+};
+
+const accessArgs = (user: typeof editor | null) =>
+  ({
+    req: {
+      payloadAPI: "REST",
+      user,
+    },
+  }) as never;
+
+const findTextField = (fields: Field[], name: string) =>
+  fields.find(
+    (field): field is TextField =>
+      field.type === "text" && field.name === name,
+  );
+
+describe("public API publication controls", () => {
+  it("limits anonymous promise reads to published records", async () => {
+    expect(await Promises.access?.read?.(accessArgs(null))).toEqual({
+      publishStatus: {
+        equals: "published",
+      },
+    });
+  });
+
+  it("lets editors read draft and unpublished promises", async () => {
+    expect(await Promises.access?.read?.(accessArgs(editor))).toBe(true);
+  });
+
+  it("hides the Meedan identifier from anonymous readers", async () => {
+    const meedanId = findTextField(Promises.fields, "meedanId");
+
+    expect(meedanId).toBeDefined();
+    expect(await meedanId?.access?.read?.(accessArgs(null))).toBe(false);
+    expect(await meedanId?.access?.read?.(accessArgs(editor))).toBe(true);
+  });
+
+  it("requires authentication to read documents", async () => {
+    expect(await Documents.access?.read?.(accessArgs(null))).toBe(false);
+    expect(await Documents.access?.read?.(accessArgs(editor))).toBe(true);
+  });
+
+  it("requires authentication to read AI extractions", async () => {
+    expect(await AIExtractions.access?.read?.(accessArgs(null))).toBe(false);
+    expect(await AIExtractions.access?.read?.(accessArgs(editor))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Add authenticatedUsers and authenticatedFieldAccess access utilities. Restrict read access for Documents and AIExtractions to authenticated users only. Update Promises collection to allow anonymous access only to published records, and add field-level access control for the meedanId field to hide it from anonymous readers. Add integration tests to validate public API access controls.

Fixes #576 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
