### PR TITLE
Harden remote-file ingestion and inbound endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,14 +52,30 @@ SMTP_FROM_NAME=
 PAYLOAD_JOBS_CRON_SCHEDULE="* * * * *"
 PAYLOAD_JOBS_QUEUE=everyMinute
 
-# Meedan Image Hosts (Optional)
+# Remote download hardening (see docs/remote-file-ingestion.md)
+# Hostname allowlist for Meedan image downloads. Comma-separated hostnames or
+# "*.suffix" wildcards. Defaults to checkmedia.org,*.checkmedia.org.
 MEEDAN_ALLOWED_IMAGE_HOSTS=
+# Max size for Meedan webhook image downloads (default 10MB)
+MEEDAN_MAX_IMAGE_BYTES=10485760
+# Meedan webhook abuse controls
+MEEDAN_SYNC_RATE_LIMIT_PER_MINUTE=60
+MEEDAN_SYNC_IDEMPOTENCY_TTL_MS=600000
 
 # Max Download Size in Bytes (Optional)
 MAX_DOWNLOAD_BYTES=104857600
+# Redirect / timeout / concurrency bounds for all remote downloads
+DOWNLOAD_MAX_REDIRECTS=3
+DOWNLOAD_RESPONSE_TIMEOUT_MS=30000
+DOWNLOAD_TOTAL_TIMEOUT_MS=300000
+MAX_CONCURRENT_DOWNLOADS=4
 
 # Airtable Upload API (for Airtable extension file uploads)
 AIRTABLE_UPLOAD_TOKEN=
 AIRTABLE_UPLOAD_ALLOWED_ORIGINS=
 AIRTABLE_UPLOAD_MAX_IMAGE_BYTES=12582912 # 12MB
 AIRTABLE_UPLOAD_MAX_DOCUMENT_BYTES=1073741824 # 100MB
+# Airtable upload abuse controls (per app instance)
+AIRTABLE_UPLOAD_RATE_LIMIT_PER_MINUTE=30
+AIRTABLE_UPLOAD_MAX_CONCURRENT=4
+AIRTABLE_UPLOAD_DAILY_MAX_BYTES=5368709120 # 5GB/day

--- a/docs/remote-file-ingestion.md
+++ b/docs/remote-file-ingestion.md
@@ -1,0 +1,116 @@
+# Remote-file ingestion and inbound endpoint hardening
+
+This document describes the safety boundary around remote downloads (Meedan
+Check images, Airtable document URLs) and inbound state-changing endpoints
+(`/api/meedan-sync`, `/api/airtable-upload`), plus the quotas that bound
+their resource usage.
+
+## Remote downloads (`downloadFile` in `src/utils/files.ts`)
+
+All remote downloads share these controls:
+
+- **HTTPS only.** Plain `http:` (and any other scheme) is rejected.
+- **SSRF address filtering.** The hostname is resolved before the request is
+  made and the download is rejected when any resolved address is private
+  (`10/8`, `172.16/12`, `192.168/16`), loopback, link-local (including the
+  `169.254.169.254` cloud-metadata endpoint), CGNAT, multicast, reserved, or
+  a blocked-range IPv6 equivalent (`::1`, `fe80::/10`, `fc00::/7`,
+  IPv4-mapped, NAT64, 6to4). IP-literal URLs are checked directly. See
+  `src/utils/ssrf.ts`.
+- **Redirect bounding.** Redirects are followed manually. Every redirect
+  destination is re-validated (HTTPS + address filtering + DNS check) before
+  it is dialled. At most `DOWNLOAD_MAX_REDIRECTS` (default **3**) hops.
+- **Timeouts.** Response headers must arrive within
+  `DOWNLOAD_RESPONSE_TIMEOUT_MS` (default **30s**) per hop; the whole
+  download must finish within `DOWNLOAD_TOTAL_TIMEOUT_MS` (default **5min**).
+- **Byte limit.** Enforced from `Content-Length` when present and again
+  while streaming (`MAX_DOWNLOAD_BYTES`, default **1GB**; Meedan webhook
+  images use `MEEDAN_MAX_IMAGE_BYTES`, default **10MB**).
+- **Concurrency.** At most `MAX_CONCURRENT_DOWNLOADS` (default **4**)
+  simultaneous downloads per app instance; the rest queue.
+- **Content validation.** Callers pass `allowedMimeTypes`; with
+  `verifySignature: true` the downloaded file's magic bytes must match its
+  `Content-Type` (see `src/utils/fileSignature.ts`).
+
+### Meedan-specific rules
+
+Meedan image URLs (webhook `/api/meedan-sync` and the `syncMeedanPromises`
+workflow) additionally require the hostname to match the allowlist in
+`MEEDAN_ALLOWED_IMAGE_HOSTS` (comma-separated hostnames or `*.suffix`
+wildcards; default `checkmedia.org,*.checkmedia.org`). SVG is not accepted
+as an image type.
+
+Airtable document downloads (`downloadDocuments` task) accept any public
+HTTPS host (editors legitimately link documents from arbitrary sites) but
+get all of the shared controls above. Note that plain-HTTP document links
+that may previously have worked are now rejected; the task marks the
+Airtable row as failed so editors can fix the link.
+
+One internal exception: the `extractDocuments` task re-fetches the app's
+*own* media from `NEXT_PUBLIC_APP_URL` (which is `http://localhost` in
+development). That app-built URL uses `allowPrivateAddresses`/HTTP
+explicitly; the option must never be used for URLs containing external
+input.
+
+### Residual risk
+
+DNS is validated at lookup time immediately before each request; a
+malicious authoritative DNS server with a 0-TTL record could still attempt
+a rebinding race between validation and connection. The hostname allowlist
+for Meedan downloads and the network egress policy of the hosting
+environment are the mitigations for that residual window.
+
+## Uploads (`/api/airtable-upload`)
+
+- **Authentication.** `Bearer` token compared in constant time
+  (`AIRTABLE_UPLOAD_TOKEN`).
+- **Type validation.** The file extension and the multipart MIME type must
+  both be allowed for the declared upload kind *and* agree with each other;
+  the file's magic bytes must then match the claimed type. SVG uploads are
+  rejected entirely.
+- **Size quotas.** `AIRTABLE_UPLOAD_MAX_IMAGE_BYTES` (default **12MB**) and
+  `AIRTABLE_UPLOAD_MAX_DOCUMENT_BYTES` (default **1GB**), enforced while
+  streaming.
+- **Rate limit.** `AIRTABLE_UPLOAD_RATE_LIMIT_PER_MINUTE` requests per
+  client IP per minute (default **30**).
+- **Concurrency.** At most `AIRTABLE_UPLOAD_MAX_CONCURRENT` uploads
+  processed simultaneously per instance (default **4**).
+- **Storage/cost budget.** Accepted upload bytes are capped at
+  `AIRTABLE_UPLOAD_DAILY_MAX_BYTES` per rolling 24h window per instance
+  (default **5GB**). This bounds storage growth and S3/bandwidth cost from
+  a leaked token; raise it deliberately if legitimate volume grows.
+
+## Meedan webhook (`/api/meedan-sync`)
+
+- **Authentication.** `WEBHOOK_SECRET_KEY` compared in constant time.
+- **Rate limit.** `MEEDAN_SYNC_RATE_LIMIT_PER_MINUTE` requests per client
+  IP per minute (default **60**).
+- **Replay / duplicate delivery protection.** Each request body is
+  fingerprinted (SHA-256). Within
+  `MEEDAN_SYNC_IDEMPOTENCY_TTL_MS` (default **10min**):
+  - a duplicate of a completed request replays the recorded response
+    (marked `"replayed": true`) without re-processing;
+  - a duplicate of an in-flight request gets `409 Conflict`;
+  - `5xx` outcomes are not recorded, so genuine retries re-process.
+
+## Media serving
+
+- SVG is no longer accepted from any ingestion path (uploads, Meedan
+  images).
+- Locally served uploads (`/api/media/file/*`) are sent with
+  `X-Content-Type-Options: nosniff` and a sandboxing
+  `Content-Security-Policy` so stored content cannot execute scripts on the
+  application origin (`next.config.mjs`).
+- For full origin isolation in production, serve media from the S3/CDN
+  origin (already supported via `@payloadcms/storage-s3`) rather than the
+  app origin.
+
+## Deployment note on in-memory guards
+
+Rate limits, idempotency records, concurrency gates, and byte budgets are
+kept in process memory (`src/utils/requestGuards.ts`). They are enforced
+**per app instance** and reset on restart. With `N` replicas the effective
+global quota is up to `N ×` the configured value. If the deployment scales
+beyond a small number of replicas, back these guards with a shared store
+(e.g. Redis) — the call sites are already funnelled through
+`requestGuards.ts`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,26 @@ const nextConfig = {
     ignoreDuringBuilds: false,
   },
   output: "standalone",
+  async headers() {
+    return [
+      {
+        // Locally stored uploads (Payload serves them from this route). The
+        // sandboxing CSP and nosniff header ensure that even a hostile file
+        // (e.g. HTML or SVG smuggled into storage) cannot execute scripts or
+        // be MIME-sniffed into something executable. In production, prefer
+        // serving media from a separate origin (S3/CDN) for full isolation.
+        source: "/api/media/file/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+          },
+          { key: "Content-Disposition", value: "inline" },
+        ],
+      },
+    ];
+  },
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       ".cjs": [".cts", ".cjs"],

--- a/src/app/api/airtable-upload/route.ts
+++ b/src/app/api/airtable-upload/route.ts
@@ -10,8 +10,15 @@ import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 
 import { getGlobalPayload } from "@/lib/payload";
+import { validateFileSignature } from "@/utils/fileSignature";
+import {
+  createByteBudget,
+  createConcurrencyGate,
+  createRateLimiter,
+} from "@/utils/requestGuards";
 import {
   getCorsHeaders,
+  getUploadFileExtension,
   getUploadMaxBytes,
   inferUploadKindFromMetadata,
   isAuthorizedUploadRequest,
@@ -25,6 +32,20 @@ import {
 
 export const runtime = "nodejs";
 const ROUTE_TAG = "airtable-upload";
+
+// Per-process abuse controls; documented in docs/remote-file-ingestion.md.
+const uploadRateLimiter = createRateLimiter({
+  limit: Number(process.env.AIRTABLE_UPLOAD_RATE_LIMIT_PER_MINUTE) || 30,
+  windowMs: 60_000,
+});
+const uploadConcurrencyGate = createConcurrencyGate(
+  Number(process.env.AIRTABLE_UPLOAD_MAX_CONCURRENT) || 4,
+);
+const uploadByteBudget = createByteBudget({
+  maxBytes:
+    Number(process.env.AIRTABLE_UPLOAD_DAILY_MAX_BYTES) ||
+    5 * 1024 * 1024 * 1024,
+});
 
 type UploadSuccessResponse = {
   ok: true;
@@ -68,6 +89,18 @@ const getTraceId = (request: NextRequest): string => {
   }
 
   return randomUUID();
+};
+
+const getClientIp = (request: NextRequest): string | null => {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const first = forwardedFor.split(",")[0]?.trim();
+    if (first) {
+      return first;
+    }
+  }
+
+  return request.headers.get("x-real-ip")?.trim() ?? null;
 };
 
 const toErrorDetails = (error: unknown): Record<string, unknown> => {
@@ -617,6 +650,45 @@ export const POST = async (request: NextRequest) => {
     );
   }
 
+  if (!uploadRateLimiter.allow(getClientIp(request) ?? "unknown")) {
+    logEvent({
+      level: "warn",
+      event: "rateLimit.exceeded",
+      details: {
+        status: 429,
+      },
+    });
+    return jsonResponse(
+      request,
+      429,
+      {
+        ok: false,
+        error: "Too many upload requests. Try again shortly.",
+      },
+      traceId,
+    );
+  }
+
+  const releaseUploadSlot = uploadConcurrencyGate.tryAcquire();
+  if (!releaseUploadSlot) {
+    logEvent({
+      level: "warn",
+      event: "concurrency.saturated",
+      details: {
+        status: 429,
+      },
+    });
+    return jsonResponse(
+      request,
+      429,
+      {
+        ok: false,
+        error: "Too many concurrent uploads. Try again shortly.",
+      },
+      traceId,
+    );
+  }
+
   try {
     return await Sentry.startSpan(
       {
@@ -658,6 +730,57 @@ export const POST = async (request: NextRequest) => {
             hasAlt: Boolean(parsedUpload.alt?.trim()),
           },
         });
+
+        if (!uploadByteBudget.tryConsume(parsedUpload.filesize)) {
+          logEvent({
+            level: "warn",
+            event: "quota.dailyByteBudgetExceeded",
+            details: {
+              status: 429,
+              uploadSizeBytes: parsedUpload.filesize,
+            },
+          });
+          return jsonResponse(
+            request,
+            429,
+            {
+              ok: false,
+              error: "Upload storage budget exceeded. Try again later.",
+            },
+            traceId,
+          );
+        }
+
+        // Reject files whose content does not match the extension/MIME they
+        // claim (e.g. an executable renamed to .png).
+        const signatureCheck = await validateFileSignature(
+          parsedUpload.tempFilePath,
+          {
+            mimeType: parsedUpload.mimeType,
+            extension: getUploadFileExtension(parsedUpload.originalFilename),
+          },
+        );
+        if (!signatureCheck.ok) {
+          logEvent({
+            level: "warn",
+            event: "upload.signatureMismatch",
+            details: {
+              status: 415,
+              uploadMimeType: parsedUpload.mimeType,
+              originalFilename: parsedUpload.originalFilename,
+              reason: signatureCheck.message,
+            },
+          });
+          return jsonResponse(
+            request,
+            415,
+            {
+              ok: false,
+              error: signatureCheck.message,
+            },
+            traceId,
+          );
+        }
 
         const payload = await getGlobalPayload();
         const alt =
@@ -893,6 +1016,7 @@ export const POST = async (request: NextRequest) => {
       traceId,
     );
   } finally {
+    releaseUploadSlot();
     if (tempFilePath) {
       try {
         await unlink(tempFilePath);

--- a/src/app/api/airtable-upload/utils.ts
+++ b/src/app/api/airtable-upload/utils.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { safeCompare } from "@/utils/requestGuards";
 
 export type UploadKind = "document" | "entityImage";
 
@@ -31,13 +31,14 @@ const DOCUMENT_EXTENSIONS = new Set([
   ".csv",
 ]);
 
+// SVG is intentionally not accepted: it can carry embedded scripts and the
+// product does not need vector uploads.
 const IMAGE_MIME_TYPES = new Set([
   "image/jpeg",
   "image/jpg",
   "image/png",
   "image/gif",
   "image/webp",
-  "image/svg+xml",
 ]);
 
 const IMAGE_EXTENSIONS = new Set([
@@ -46,8 +47,32 @@ const IMAGE_EXTENSIONS = new Set([
   ".png",
   ".gif",
   ".webp",
-  ".svg",
 ]);
+
+// Which MIME types legitimately accompany each extension. Extension and
+// MIME metadata must agree before the file signature is even inspected.
+const EXTENSION_TO_MIME_TYPES: Record<string, string[]> = {
+  ".pdf": ["application/pdf"],
+  ".doc": ["application/msword"],
+  ".docx": [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ],
+  ".xls": ["application/vnd.ms-excel"],
+  ".xlsx": [
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ],
+  ".ppt": ["application/vnd.ms-powerpoint"],
+  ".pptx": [
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ],
+  ".txt": ["text/plain"],
+  ".csv": ["text/csv", "text/plain"],
+  ".jpg": ["image/jpeg", "image/jpg"],
+  ".jpeg": ["image/jpeg", "image/jpg"],
+  ".png": ["image/png"],
+  ".gif": ["image/gif"],
+  ".webp": ["image/webp"],
+};
 
 const formatBytesToMb = (bytes: number): string =>
   `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
@@ -155,17 +180,6 @@ const isAllowedOrigin = (
   return allowedOrigins.some((rule) => isOriginMatchedByRule(requestOrigin, rule));
 };
 
-const safeCompare = (left: string, right: string): boolean => {
-  const leftBuffer = Buffer.from(left);
-  const rightBuffer = Buffer.from(right);
-
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
-
-  return timingSafeEqual(leftBuffer, rightBuffer);
-};
-
 const getExtension = (fileName: string): string => {
   const trimmed = fileName.trim();
   if (!trimmed.includes(".")) {
@@ -205,7 +219,9 @@ export const validateUploadMetadata = (
   const extensionAllowed =
     extension.length > 0 ? policy.allowedExtensions.has(extension) : false;
 
-  if (!mimeAllowed && !extensionAllowed) {
+  // Both signals must be present, allowed for this upload kind, and agree
+  // with each other — a mismatch means the file is lying about its type.
+  if (!mimeAllowed || !extensionAllowed) {
     return {
       ok: false,
       status: 415,
@@ -213,8 +229,20 @@ export const validateUploadMetadata = (
     };
   }
 
+  const expectedMimeTypes = EXTENSION_TO_MIME_TYPES[extension] ?? [];
+  if (!expectedMimeTypes.includes(mimeType)) {
+    return {
+      ok: false,
+      status: 415,
+      message: `File extension "${extension}" does not match MIME type "${mimeType}".`,
+    };
+  }
+
   return { ok: true };
 };
+
+export const getUploadFileExtension = (fileName: string): string =>
+  getExtension(fileName);
 
 export const inferUploadKindFromMetadata = (
   metadata: UploadMetadataValidationInput,

--- a/src/app/api/meedan-sync/route.ts
+++ b/src/app/api/meedan-sync/route.ts
@@ -1,12 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { unlink } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import * as Sentry from "@sentry/nextjs";
 
 import { ValidationError } from "payload";
 import { getGlobalPayload } from "@/lib/payload";
 import { downloadFile } from "@/utils/files";
+import {
+  createIdempotencyCache,
+  createRateLimiter,
+  safeCompare,
+} from "@/utils/requestGuards";
+import { assertSafeRemoteUrl, UnsafeRemoteUrlError } from "@/utils/ssrf";
+import {
+  getMeedanAllowedImageHosts,
+  MEEDAN_ALLOWED_IMAGE_MIME_TYPES,
+} from "@/lib/meedanMedia";
 import type { Promise as PayloadPromise } from "@/payload-types";
 import {
   buildMeedanIdCandidates,
@@ -19,14 +29,16 @@ const WEBHOOK_SECRET_ENV_KEY = "WEBHOOK_SECRET_KEY";
 const ROUTE_TAG = "meedan-sync";
 const DEFAULT_MAX_IMAGE_BYTES =
   Number(process.env.MEEDAN_MAX_IMAGE_BYTES) || 10 * 1024 * 1024;
-const ALLOWED_IMAGE_MIME_TYPES = [
-  "image/jpeg",
-  "image/jpg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-  "image/svg+xml",
-];
+
+// Per-process abuse controls: bound repeated deliveries and make retried /
+// duplicated webhook deliveries idempotent.
+const rateLimiter = createRateLimiter({
+  limit: Number(process.env.MEEDAN_SYNC_RATE_LIMIT_PER_MINUTE) || 60,
+  windowMs: 60_000,
+});
+const idempotencyCache = createIdempotencyCache({
+  ttlMs: Number(process.env.MEEDAN_SYNC_IDEMPOTENCY_TTL_MS) || 10 * 60_000,
+});
 
 type WithOptionalId = {
   id?: unknown;
@@ -155,6 +167,9 @@ export const POST = async (request: NextRequest) => {
   const userAgent = request.headers.get("user-agent")?.trim() ?? null;
   let annotationType: string | null = null;
   let meedanId: string | null = null;
+  // Fingerprint of the raw request body; when set, respond() records the
+  // outcome so duplicate deliveries replay it instead of re-processing.
+  let idempotencyKey: string | null = null;
 
   const buildLogData = (details: Record<string, unknown> = {}) => ({
     route: ROUTE_TAG,
@@ -280,6 +295,17 @@ export const POST = async (request: NextRequest) => {
       });
     }
 
+    if (idempotencyKey) {
+      // Deterministic outcomes (including 4xx validation failures) are
+      // recorded so duplicate deliveries replay them; 5xx outcomes are
+      // released so a retry can be re-processed.
+      if (status < 500) {
+        idempotencyCache.complete(idempotencyKey, { status, body });
+      } else {
+        idempotencyCache.release(idempotencyKey);
+      }
+    }
+
     return NextResponse.json(body, {
       status,
       headers: {
@@ -307,7 +333,7 @@ export const POST = async (request: NextRequest) => {
 
   const providedSecret = request.headers.get("authorization")?.trim() ?? null;
 
-  if (!providedSecret || providedSecret !== configuredSecret) {
+  if (!providedSecret || !safeCompare(providedSecret, configuredSecret)) {
     return respond({
       status: 401,
       body: { error: "Unauthorized" },
@@ -319,10 +345,21 @@ export const POST = async (request: NextRequest) => {
     });
   }
 
+  if (!rateLimiter.allow(clientIp ?? "unknown")) {
+    return respond({
+      status: 429,
+      body: { error: "Too many requests" },
+      event: "rateLimit.exceeded",
+      level: "warn",
+    });
+  }
+
+  let rawBody: string;
   let parsed: MeedanWebhookPayload;
 
   try {
-    parsed = await request.json();
+    rawBody = await request.text();
+    parsed = JSON.parse(rawBody);
   } catch (error) {
     return respond({
       status: 400,
@@ -332,6 +369,34 @@ export const POST = async (request: NextRequest) => {
       error,
     });
   }
+
+  const bodyFingerprint = createHash("sha256").update(rawBody).digest("hex");
+  const idempotency = idempotencyCache.begin(bodyFingerprint);
+
+  if (idempotency.state === "replay") {
+    return respond({
+      status: idempotency.record.status,
+      body: { ...idempotency.record.body, replayed: true },
+      event: "request.replayedDuplicate",
+      details: {
+        bodyFingerprint,
+      },
+    });
+  }
+
+  if (idempotency.state === "in-flight") {
+    return respond({
+      status: 409,
+      body: { error: "Duplicate request is already being processed" },
+      event: "request.duplicateInFlight",
+      level: "warn",
+      details: {
+        bodyFingerprint,
+      },
+    });
+  }
+
+  idempotencyKey = bodyFingerprint;
 
   annotationType = parsed?.object?.annotation_type?.trim() ?? null;
   if (annotationType && annotationType !== "report_design") {
@@ -507,7 +572,14 @@ export const POST = async (request: NextRequest) => {
       });
     }
 
-    if (!imageUrl.startsWith("https://")) {
+    try {
+      // HTTPS + configured hostname allowlist + blocked-address checks. The
+      // same rules are re-applied (including per-redirect) inside
+      // downloadFile; this early check produces a clean 400 for bad URLs.
+      assertSafeRemoteUrl(new URL(imageUrl), {
+        allowedHostnames: getMeedanAllowedImageHosts(),
+      });
+    } catch (error) {
       return respond({
         status: 400,
         body: { error: "Invalid image URL" },
@@ -515,6 +587,8 @@ export const POST = async (request: NextRequest) => {
         level: "warn",
         details: {
           imageUrl,
+          reason:
+            error instanceof UnsafeRemoteUrlError ? error.message : "unparseable",
         },
       });
     }
@@ -532,8 +606,10 @@ export const POST = async (request: NextRequest) => {
 
     try {
       filePath = await downloadFile(imageUrl, {
-        allowedMimeTypes: ALLOWED_IMAGE_MIME_TYPES,
+        allowedMimeTypes: MEEDAN_ALLOWED_IMAGE_MIME_TYPES,
+        allowedHostnames: getMeedanAllowedImageHosts(),
         maxBytes: DEFAULT_MAX_IMAGE_BYTES,
+        verifySignature: true,
       });
       logEvent({
         level: "info",

--- a/src/lib/meedanMedia.ts
+++ b/src/lib/meedanMedia.ts
@@ -1,0 +1,28 @@
+import { parseHostnameAllowlist } from "@/utils/ssrf";
+
+/**
+ * Shared policy for media downloaded from Meedan Check.
+ *
+ * SVG is intentionally excluded: it can embed scripts and is not required
+ * for report imagery.
+ */
+export const MEEDAN_ALLOWED_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+
+// Meedan Check assets are served from checkmedia.org subdomains by default.
+// Override with MEEDAN_ALLOWED_IMAGE_HOSTS (comma-separated hostnames or
+// "*.suffix" wildcards) when assets live elsewhere (e.g. an S3 bucket).
+const DEFAULT_MEEDAN_IMAGE_HOSTS = ["checkmedia.org", "*.checkmedia.org"];
+
+export const getMeedanAllowedImageHosts = (): string[] => {
+  const configured = parseHostnameAllowlist(
+    process.env.MEEDAN_ALLOWED_IMAGE_HOSTS,
+  );
+
+  return configured.length > 0 ? configured : DEFAULT_MEEDAN_IMAGE_HOSTS;
+};

--- a/src/lib/syncMeedanReports.ts
+++ b/src/lib/syncMeedanReports.ts
@@ -7,6 +7,10 @@ import type {
   Promise as PromiseDoc,
 } from "@/payload-types";
 import type { PublishedReport } from "@/lib/meedan";
+import {
+  getMeedanAllowedImageHosts,
+  MEEDAN_ALLOWED_IMAGE_MIME_TYPES,
+} from "@/lib/meedanMedia";
 import { getGlobalPayload } from "@/lib/payload";
 import { downloadFile } from "@/utils/files";
 
@@ -228,7 +232,11 @@ export const syncMeedanReports = async ({
 
     let filePath: string | null = null;
     try {
-      filePath = await downloadFile(url);
+      filePath = await downloadFile(url, {
+        allowedMimeTypes: MEEDAN_ALLOWED_IMAGE_MIME_TYPES,
+        allowedHostnames: getMeedanAllowedImageHosts(),
+        verifySignature: true,
+      });
 
       const media = (await payload.create({
         collection: "media",

--- a/src/tasks/extractDocuments.ts
+++ b/src/tasks/extractDocuments.ts
@@ -161,7 +161,13 @@ export const ExtractDocuments: TaskConfig<"extractDocuments"> = {
                 fileUrl: url,
               });
               try {
-                tempFilePath = await downloadFile(url);
+                // This URL is built from the app's own configured origin and
+                // its own media path, so the SSRF address checks are relaxed
+                // (in development NEXT_PUBLIC_APP_URL is http://localhost).
+                tempFilePath = await downloadFile(url, {
+                  requireHttps: false,
+                  allowPrivateAddresses: true,
+                });
                 fileInput = tempFilePath;
 
                 logger.info({

--- a/src/utils/fileSignature.ts
+++ b/src/utils/fileSignature.ts
@@ -1,0 +1,146 @@
+import { open } from "node:fs/promises";
+
+/**
+ * Magic-byte validation: confirms that a file's leading bytes match its
+ * claimed MIME type (or extension) so a spoofed Content-Type / renamed file
+ * cannot smuggle a different format into storage.
+ */
+
+const HEADER_LENGTH = 512;
+
+type SignatureCheck = (header: Buffer) => boolean;
+
+const startsWith =
+  (bytes: number[], offset = 0): SignatureCheck =>
+  (header) => {
+    if (header.length < offset + bytes.length) {
+      return false;
+    }
+    return bytes.every((byte, index) => header[offset + index] === byte);
+  };
+
+const isRiffWebp: SignatureCheck = (header) =>
+  startsWith([0x52, 0x49, 0x46, 0x46])(header) &&
+  startsWith([0x57, 0x45, 0x42, 0x50], 8)(header);
+
+const JPEG = startsWith([0xff, 0xd8, 0xff]);
+const PNG = startsWith([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const GIF = (header: Buffer) =>
+  startsWith([0x47, 0x49, 0x46, 0x38, 0x37, 0x61])(header) ||
+  startsWith([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])(header);
+const PDF = startsWith([0x25, 0x50, 0x44, 0x46]); // %PDF
+const ZIP = (header: Buffer) =>
+  startsWith([0x50, 0x4b, 0x03, 0x04])(header) ||
+  startsWith([0x50, 0x4b, 0x05, 0x06])(header) ||
+  startsWith([0x50, 0x4b, 0x07, 0x08])(header);
+const OLE2 = startsWith([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+
+const BINARY_SIGNATURES: SignatureCheck[] = [
+  JPEG,
+  PNG,
+  GIF,
+  isRiffWebp,
+  PDF,
+  ZIP,
+  OLE2,
+];
+
+// Plain-text formats have no signature: accept them only when they contain
+// no NUL bytes and do not start with a known binary signature.
+const isPlausibleText: SignatureCheck = (header) => {
+  if (header.length === 0) {
+    return false;
+  }
+  if (BINARY_SIGNATURES.some((check) => check(header))) {
+    return false;
+  }
+  return !header.includes(0);
+};
+
+const SIGNATURES_BY_MIME: Record<string, SignatureCheck> = {
+  "image/jpeg": JPEG,
+  "image/jpg": JPEG,
+  "image/png": PNG,
+  "image/gif": GIF,
+  "image/webp": isRiffWebp,
+  "application/pdf": PDF,
+  "application/msword": OLE2,
+  "application/vnd.ms-excel": OLE2,
+  "application/vnd.ms-powerpoint": OLE2,
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    ZIP,
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ZIP,
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    ZIP,
+  "text/plain": isPlausibleText,
+  "text/csv": isPlausibleText,
+};
+
+const SIGNATURES_BY_EXTENSION: Record<string, SignatureCheck> = {
+  ".jpg": JPEG,
+  ".jpeg": JPEG,
+  ".png": PNG,
+  ".gif": GIF,
+  ".webp": isRiffWebp,
+  ".pdf": PDF,
+  ".doc": OLE2,
+  ".xls": OLE2,
+  ".ppt": OLE2,
+  ".docx": ZIP,
+  ".xlsx": ZIP,
+  ".pptx": ZIP,
+  ".txt": isPlausibleText,
+  ".csv": isPlausibleText,
+};
+
+export type FileSignatureValidation =
+  | { ok: true }
+  | { ok: false; message: string };
+
+export type FileSignatureClaim = {
+  mimeType?: string | null;
+  extension?: string | null;
+};
+
+export const validateBufferSignature = (
+  header: Buffer,
+  { mimeType, extension }: FileSignatureClaim,
+): FileSignatureValidation => {
+  const normalizedMime = (mimeType ?? "").trim().toLowerCase();
+  const normalizedExtension = (extension ?? "").trim().toLowerCase();
+
+  const check =
+    SIGNATURES_BY_MIME[normalizedMime] ??
+    SIGNATURES_BY_EXTENSION[normalizedExtension] ??
+    null;
+
+  if (!check) {
+    // No signature registered for the claimed type; nothing to verify.
+    return { ok: true };
+  }
+
+  if (!check(header)) {
+    return {
+      ok: false,
+      message: `File content does not match the claimed type "${
+        normalizedMime || normalizedExtension
+      }"`,
+    };
+  }
+
+  return { ok: true };
+};
+
+export const validateFileSignature = async (
+  filePath: string,
+  claim: FileSignatureClaim,
+): Promise<FileSignatureValidation> => {
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(HEADER_LENGTH);
+    const { bytesRead } = await handle.read(buffer, 0, HEADER_LENGTH, 0);
+    return validateBufferSignature(buffer.subarray(0, bytesRead), claim);
+  } finally {
+    await handle.close();
+  }
+};

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -6,6 +6,13 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 
+import { validateFileSignature } from "@/utils/fileSignature";
+import {
+  assertResolvesToPublicAddresses,
+  assertSafeRemoteUrl,
+  type LookupFn,
+} from "@/utils/ssrf";
+
 export const mimeToExtension: Record<string, string> = {
   "application/pdf": ".pdf",
   "application/msword": ".doc",
@@ -41,11 +48,67 @@ const tempDir = join(dirName, "..", "..", "temp");
 
 const DEFAULT_MAX_DOWNLOAD_BYTES =
   Number(process.env.MAX_DOWNLOAD_BYTES) || 1024 * 1024 * 1024;
+const DEFAULT_MAX_REDIRECTS =
+  Number(process.env.DOWNLOAD_MAX_REDIRECTS) || 3;
+// Time allowed to connect and receive response headers, per redirect hop.
+const DEFAULT_RESPONSE_TIMEOUT_MS =
+  Number(process.env.DOWNLOAD_RESPONSE_TIMEOUT_MS) || 30_000;
+// Overall deadline for the whole download, body streaming included.
+const DEFAULT_TOTAL_TIMEOUT_MS =
+  Number(process.env.DOWNLOAD_TOTAL_TIMEOUT_MS) || 5 * 60_000;
+const MAX_CONCURRENT_DOWNLOADS =
+  Number(process.env.MAX_CONCURRENT_DOWNLOADS) || 4;
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+// Process-wide semaphore so a burst of webhook/task activity cannot open an
+// unbounded number of simultaneous remote downloads.
+let activeDownloads = 0;
+const downloadWaiters: Array<() => void> = [];
+
+const acquireDownloadSlot = async (): Promise<void> => {
+  if (activeDownloads < MAX_CONCURRENT_DOWNLOADS) {
+    activeDownloads += 1;
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    downloadWaiters.push(resolve);
+  });
+  activeDownloads += 1;
+};
+
+const releaseDownloadSlot = (): void => {
+  activeDownloads -= 1;
+  const next = downloadWaiters.shift();
+  if (next) {
+    next();
+  }
+};
 
 type DownloadFileOptions = {
   allowedMimeTypes?: string[];
   maxBytes?: number;
   fileName?: string;
+  /**
+   * Hostname allowlist applied to the initial URL (exact hostnames or
+   * "*.suffix" wildcards). Redirect hops always get HTTPS + address checks.
+   */
+  allowedHostnames?: string[];
+  requireHttps?: boolean;
+  /**
+   * Skips SSRF address checks. ONLY for URLs the application built itself
+   * against its own configured origin (e.g. fetching its own media in
+   * development) — never for URLs containing external input.
+   */
+  allowPrivateAddresses?: boolean;
+  maxRedirects?: number;
+  responseTimeoutMs?: number;
+  totalTimeoutMs?: number;
+  /** Verify magic bytes of the downloaded file against its content type. */
+  verifySignature?: boolean;
+  /** DNS lookup override, for tests. */
+  lookup?: LookupFn;
 };
 
 const MAX_FILE_NAME_LENGTH = 100;
@@ -73,11 +136,86 @@ export const removeDownloadedFile = async (
   await unlink(filePath).catch(() => {});
 };
 
+/**
+ * Follows redirects manually so every destination is re-validated against
+ * the SSRF rules before it is dialled, with a bounded hop count and a
+ * per-hop response-header timeout.
+ */
+const fetchWithValidatedRedirects = async (
+  initialUrl: URL,
+  {
+    allowedHostnames,
+    requireHttps,
+    allowPrivateAddresses,
+    maxRedirects,
+    responseTimeoutMs,
+    lookup,
+  }: {
+    allowedHostnames?: string[];
+    requireHttps: boolean;
+    allowPrivateAddresses: boolean;
+    maxRedirects: number;
+    responseTimeoutMs: number;
+    lookup?: LookupFn;
+  },
+): Promise<Response> => {
+  let currentUrl = initialUrl;
+
+  for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    assertSafeRemoteUrl(currentUrl, {
+      // The allowlist constrains where a download may start; redirect hops
+      // still must be public HTTPS hosts.
+      allowedHostnames: hop === 0 ? allowedHostnames : undefined,
+      requireHttps,
+      allowPrivateAddresses,
+    });
+    if (!allowPrivateAddresses) {
+      await assertResolvesToPublicAddresses(currentUrl, lookup);
+    }
+
+    const res = await fetch(currentUrl, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(responseTimeoutMs),
+    });
+
+    if (!REDIRECT_STATUS_CODES.has(res.status)) {
+      return res;
+    }
+
+    // Discard the redirect body so the connection can be reused/closed.
+    await res.body?.cancel().catch(() => {});
+
+    const location = res.headers.get("location");
+    if (!location) {
+      throw new Error(
+        `Redirect response from ${currentUrl.host} is missing a Location header`,
+      );
+    }
+
+    if (hop === maxRedirects) {
+      throw new Error(
+        `Download exceeded the maximum of ${maxRedirects} redirects`,
+      );
+    }
+
+    currentUrl = new URL(location, currentUrl);
+  }
+
+  // Unreachable: the loop always returns or throws.
+  throw new Error("Redirect handling exhausted unexpectedly");
+};
+
 export const downloadFile = async (
   url: string,
   options: DownloadFileOptions = {},
 ) => {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_DOWNLOAD_BYTES;
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const responseTimeoutMs =
+    options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  const totalTimeoutMs = options.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS;
+  const requireHttps = options.requireHttps ?? true;
+
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(url);
@@ -85,71 +223,110 @@ export const downloadFile = async (
     throw new Error(`Invalid download URL: ${url}`);
   }
 
-  const res = await fetch(parsedUrl);
-  if (!res.ok) {
-    throw new Error(
-      `Error downloading file from: ${url}. Status ${res.status}, Error: ${res.statusText}`,
-    );
-  }
-
-  const contentLength = Number(res.headers.get("content-length"));
-  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
-    throw new Error(
-      `Download exceeds size limit (${contentLength} > ${maxBytes})`,
-    );
-  }
-
-  const requestedFileName = sanitizeFileName(options.fileName ?? "");
-  const fileName = requestedFileName || `file-${randomUUID()}`;
-  // Named files get their own subdirectory so concurrent downloads of
-  // same-named files cannot clobber each other in the shared temp dir.
-  const downloadDir = requestedFileName
-    ? join(tempDir, randomUUID())
-    : tempDir;
-
-  const contentType = res.headers.get("content-type")?.split(";")[0] || "";
-  if (
-    options.allowedMimeTypes &&
-    options.allowedMimeTypes.length > 0 &&
-    !options.allowedMimeTypes.includes(contentType)
-  ) {
-    throw new Error(`Unsupported content-type: ${contentType || "unknown"}`);
-  }
-
-  if (!res.body) {
-    throw new Error("Missing response body");
-  }
-
-  await mkdir(downloadDir, { recursive: true });
-
-  const extension = mimeToExtension[contentType] || "";
-  const docFileName = `${fileName}${extension}`;
-  const filePath = join(downloadDir, docFileName);
-
-  // Stream the response straight to disk so memory usage stays constant
-  // regardless of file size; enforce the size limit as bytes arrive.
-  let total = 0;
-  const enforceSizeLimit = async function* (source: AsyncIterable<Uint8Array>) {
-    for await (const chunk of source) {
-      total += chunk.length;
-      if (total > maxBytes) {
-        throw new Error(`Download exceeds size limit (${total} > ${maxBytes})`);
-      }
-      yield chunk;
-    }
-  };
+  await acquireDownloadSlot();
 
   try {
-    await pipeline(
-      enforceSizeLimit(Readable.fromWeb(res.body as never)),
-      createWriteStream(filePath),
-    );
-  } catch (error) {
-    await removeDownloadedFile(filePath).catch(() => {});
-    throw error;
-  }
+    const startedAt = Date.now();
+    const res = await fetchWithValidatedRedirects(parsedUrl, {
+      allowedHostnames: options.allowedHostnames,
+      requireHttps,
+      allowPrivateAddresses: options.allowPrivateAddresses ?? false,
+      maxRedirects,
+      responseTimeoutMs,
+      lookup: options.lookup,
+    });
 
-  return filePath;
+    if (!res.ok) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(
+        `Error downloading file from: ${url}. Status ${res.status}, Error: ${res.statusText}`,
+      );
+    }
+
+    const contentLength = Number(res.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(
+        `Download exceeds size limit (${contentLength} > ${maxBytes})`,
+      );
+    }
+
+    const requestedFileName = sanitizeFileName(options.fileName ?? "");
+    const fileName = requestedFileName || `file-${randomUUID()}`;
+    // Named files get their own subdirectory so concurrent downloads of
+    // same-named files cannot clobber each other in the shared temp dir.
+    const downloadDir = requestedFileName
+      ? join(tempDir, randomUUID())
+      : tempDir;
+
+    const contentType = res.headers.get("content-type")?.split(";")[0] || "";
+    if (
+      options.allowedMimeTypes &&
+      options.allowedMimeTypes.length > 0 &&
+      !options.allowedMimeTypes.includes(contentType)
+    ) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(`Unsupported content-type: ${contentType || "unknown"}`);
+    }
+
+    if (!res.body) {
+      throw new Error("Missing response body");
+    }
+
+    await mkdir(downloadDir, { recursive: true });
+
+    const extension = mimeToExtension[contentType] || "";
+    const docFileName = `${fileName}${extension}`;
+    const filePath = join(downloadDir, docFileName);
+
+    // Stream the response straight to disk so memory usage stays constant
+    // regardless of file size; enforce the size limit and overall deadline
+    // as bytes arrive.
+    let total = 0;
+    const enforceStreamLimits = async function* (
+      source: AsyncIterable<Uint8Array>,
+    ) {
+      for await (const chunk of source) {
+        total += chunk.length;
+        if (total > maxBytes) {
+          throw new Error(
+            `Download exceeds size limit (${total} > ${maxBytes})`,
+          );
+        }
+        if (Date.now() - startedAt > totalTimeoutMs) {
+          throw new Error(
+            `Download exceeded the total time limit of ${totalTimeoutMs}ms`,
+          );
+        }
+        yield chunk;
+      }
+    };
+
+    try {
+      await pipeline(
+        enforceStreamLimits(Readable.fromWeb(res.body as never)),
+        createWriteStream(filePath),
+      );
+
+      if (options.verifySignature) {
+        const signatureCheck = await validateFileSignature(filePath, {
+          mimeType: contentType || null,
+        });
+        if (!signatureCheck.ok) {
+          throw new Error(
+            `Downloaded file failed content validation: ${signatureCheck.message}`,
+          );
+        }
+      }
+    } catch (error) {
+      await removeDownloadedFile(filePath).catch(() => {});
+      throw error;
+    }
+
+    return filePath;
+  } finally {
+    releaseDownloadSlot();
+  }
 };
 
 export const sha256File = async (filePath: string): Promise<string> => {

--- a/src/utils/requestGuards.ts
+++ b/src/utils/requestGuards.ts
@@ -1,0 +1,232 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * In-memory abuse controls for inbound state-changing endpoints.
+ *
+ * These guards are per-process: in a multi-instance deployment each instance
+ * enforces its own budget, so configure limits with that in mind (see
+ * docs/remote-file-ingestion.md).
+ */
+
+/** Constant-time string comparison for secrets/tokens. */
+export const safeCompare = (left: string, right: string): boolean => {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+};
+
+const MAX_TRACKED_KEYS = 10_000;
+
+export type RateLimiter = {
+  /** Returns true when the request is allowed, false when rate-limited. */
+  allow: (key: string) => boolean;
+};
+
+/**
+ * Fixed-window rate limiter. Windows are keyed per caller (IP/token) and
+ * pruned lazily so the map stays bounded.
+ */
+export const createRateLimiter = ({
+  limit,
+  windowMs,
+}: {
+  limit: number;
+  windowMs: number;
+}): RateLimiter => {
+  const windows = new Map<string, { windowStart: number; count: number }>();
+
+  const prune = (now: number) => {
+    if (windows.size <= MAX_TRACKED_KEYS) {
+      return;
+    }
+    for (const [key, entry] of windows) {
+      if (now - entry.windowStart >= windowMs) {
+        windows.delete(key);
+      }
+    }
+  };
+
+  return {
+    allow: (key: string): boolean => {
+      if (limit <= 0) {
+        return true;
+      }
+
+      const now = Date.now();
+      prune(now);
+
+      const entry = windows.get(key);
+      if (!entry || now - entry.windowStart >= windowMs) {
+        windows.set(key, { windowStart: now, count: 1 });
+        return true;
+      }
+
+      if (entry.count >= limit) {
+        return false;
+      }
+
+      entry.count += 1;
+      return true;
+    },
+  };
+};
+
+export type IdempotencyRecord = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+export type IdempotencyResult =
+  | { state: "new" }
+  | { state: "in-flight" }
+  | { state: "replay"; record: IdempotencyRecord };
+
+export type IdempotencyCache = {
+  /**
+   * Registers the key. "new" means the caller should process the request
+   * and later call complete()/release(). "in-flight" means an identical
+   * request is currently being processed. "replay" returns the recorded
+   * response of an already-completed identical request.
+   */
+  begin: (key: string) => IdempotencyResult;
+  /** Records the final response so later duplicates replay it. */
+  complete: (key: string, record: IdempotencyRecord) => void;
+  /** Drops an in-flight marker without recording a response (on failure). */
+  release: (key: string) => void;
+};
+
+type IdempotencyEntry =
+  | { state: "pending"; insertedAt: number }
+  | { state: "done"; insertedAt: number; record: IdempotencyRecord };
+
+/**
+ * TTL cache keyed by a request fingerprint (e.g. SHA-256 of the raw body).
+ * Completed requests replay their recorded response; identical concurrent
+ * requests are rejected as in-flight duplicates.
+ */
+export const createIdempotencyCache = ({
+  ttlMs,
+  maxEntries = MAX_TRACKED_KEYS,
+}: {
+  ttlMs: number;
+  maxEntries?: number;
+}): IdempotencyCache => {
+  const entries = new Map<string, IdempotencyEntry>();
+
+  const prune = (now: number) => {
+    for (const [key, entry] of entries) {
+      if (now - entry.insertedAt >= ttlMs) {
+        entries.delete(key);
+      }
+    }
+    // Drop oldest entries when the cache is still over budget (Map preserves
+    // insertion order).
+    while (entries.size > maxEntries) {
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      entries.delete(oldestKey);
+    }
+  };
+
+  return {
+    begin: (key) => {
+      const now = Date.now();
+      prune(now);
+
+      const entry = entries.get(key);
+      if (entry && now - entry.insertedAt < ttlMs) {
+        if (entry.state === "pending") {
+          return { state: "in-flight" };
+        }
+        return { state: "replay", record: entry.record };
+      }
+
+      entries.set(key, { state: "pending", insertedAt: now });
+      return { state: "new" };
+    },
+    complete: (key, record) => {
+      entries.set(key, { state: "done", insertedAt: Date.now(), record });
+    },
+    release: (key) => {
+      const entry = entries.get(key);
+      if (entry?.state === "pending") {
+        entries.delete(key);
+      }
+    },
+  };
+};
+
+export type ConcurrencyGate = {
+  /** Returns a release function when a slot is available, or null when saturated. */
+  tryAcquire: () => (() => void) | null;
+};
+
+/** Bounds the number of simultaneously processed requests per process. */
+export const createConcurrencyGate = (maxConcurrent: number): ConcurrencyGate => {
+  let active = 0;
+
+  return {
+    tryAcquire: () => {
+      if (maxConcurrent > 0 && active >= maxConcurrent) {
+        return null;
+      }
+
+      active += 1;
+      let released = false;
+      return () => {
+        if (!released) {
+          released = true;
+          active -= 1;
+        }
+      };
+    },
+  };
+};
+
+export type ByteBudget = {
+  /** Reserves bytes against the current window; false when over budget. */
+  tryConsume: (bytes: number) => boolean;
+};
+
+/**
+ * Rolling storage/cost budget: caps total accepted bytes per window
+ * (default: per day) per process.
+ */
+export const createByteBudget = ({
+  maxBytes,
+  windowMs = 24 * 60 * 60 * 1000,
+}: {
+  maxBytes: number;
+  windowMs?: number;
+}): ByteBudget => {
+  let windowStart = Date.now();
+  let consumed = 0;
+
+  return {
+    tryConsume: (bytes: number): boolean => {
+      if (maxBytes <= 0) {
+        return true;
+      }
+
+      const now = Date.now();
+      if (now - windowStart >= windowMs) {
+        windowStart = now;
+        consumed = 0;
+      }
+
+      if (consumed + bytes > maxBytes) {
+        return false;
+      }
+
+      consumed += bytes;
+      return true;
+    },
+  };
+};

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -1,0 +1,360 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+/**
+ * Guards for remote-file ingestion (SSRF protection).
+ *
+ * Every remote download must:
+ * - use HTTPS (unless explicitly relaxed),
+ * - optionally match a hostname allowlist,
+ * - never resolve to private, loopback, link-local, CGNAT, cloud-metadata,
+ *   multicast, or otherwise non-public addresses — for the initial URL and
+ *   for every redirect destination.
+ */
+
+export type LookupAddress = { address: string; family: number };
+
+export type LookupFn = (
+  hostname: string,
+) => Promise<LookupAddress[] | LookupAddress>;
+
+const defaultLookup: LookupFn = (hostname) =>
+  dnsLookup(hostname, { all: true, verbatim: true });
+
+type Ipv4Range = { base: number; maskBits: number };
+
+const ipv4ToInt = (ip: string): number | null => {
+  const parts = ip.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) {
+      return null;
+    }
+    const octet = Number(part);
+    if (octet > 255) {
+      return null;
+    }
+    value = value * 256 + octet;
+  }
+  return value >>> 0;
+};
+
+const ipv4Range = (cidr: string): Ipv4Range => {
+  const [base, bits] = cidr.split("/");
+  return { base: ipv4ToInt(base)! >>> 0, maskBits: Number(bits) };
+};
+
+// Non-public IPv4 space: unspecified, private, loopback, link-local (incl.
+// the 169.254.169.254 cloud-metadata endpoint), CGNAT, benchmarking,
+// documentation/test nets, multicast, and reserved/broadcast.
+const BLOCKED_IPV4_RANGES: Ipv4Range[] = [
+  "0.0.0.0/8",
+  "10.0.0.0/8",
+  "100.64.0.0/10",
+  "127.0.0.0/8",
+  "169.254.0.0/16",
+  "172.16.0.0/12",
+  "192.0.0.0/24",
+  "192.0.2.0/24",
+  "192.168.0.0/16",
+  "198.18.0.0/15",
+  "198.51.100.0/24",
+  "203.0.113.0/24",
+  "224.0.0.0/3",
+].map(ipv4Range);
+
+const isBlockedIpv4 = (ip: string): boolean => {
+  const value = ipv4ToInt(ip);
+  if (value === null) {
+    return true;
+  }
+
+  return BLOCKED_IPV4_RANGES.some(({ base, maskBits }) => {
+    const mask = maskBits === 0 ? 0 : (~0 << (32 - maskBits)) >>> 0;
+    return (value & mask) === (base & mask);
+  });
+};
+
+/** Expand an IPv6 address string into its 8 16-bit groups. */
+const parseIpv6Groups = (ip: string): number[] | null => {
+  let address = ip;
+
+  // Strip zone index (fe80::1%eth0).
+  const zoneIndex = address.indexOf("%");
+  if (zoneIndex !== -1) {
+    address = address.slice(0, zoneIndex);
+  }
+
+  // Convert a trailing embedded IPv4 (::ffff:127.0.0.1) into two groups.
+  const lastColon = address.lastIndexOf(":");
+  const tail = address.slice(lastColon + 1);
+  if (tail.includes(".")) {
+    const v4 = ipv4ToInt(tail);
+    if (v4 === null) {
+      return null;
+    }
+    address =
+      address.slice(0, lastColon + 1) +
+      `${((v4 >>> 16) & 0xffff).toString(16)}:${(v4 & 0xffff).toString(16)}`;
+  }
+
+  const halves = address.split("::");
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const head = halves[0] ? halves[0].split(":") : [];
+  const rest = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const fill = 8 - head.length - rest.length;
+  if (halves.length === 2 && fill < 0) {
+    return null;
+  }
+  if (halves.length === 1 && head.length !== 8) {
+    return null;
+  }
+
+  const groups = [
+    ...head,
+    ...Array.from({ length: halves.length === 2 ? fill : 0 }, () => "0"),
+    ...rest,
+  ];
+
+  if (groups.length !== 8) {
+    return null;
+  }
+
+  const parsed = groups.map((group) => Number.parseInt(group || "0", 16));
+  return parsed.every((value) => Number.isFinite(value) && value <= 0xffff)
+    ? parsed
+    : null;
+};
+
+const groupsToIpv4 = (high: number, low: number): string =>
+  `${(high >>> 8) & 0xff}.${high & 0xff}.${(low >>> 8) & 0xff}.${low & 0xff}`;
+
+const isBlockedIpv6 = (ip: string): boolean => {
+  const groups = parseIpv6Groups(ip);
+  if (!groups) {
+    return true;
+  }
+
+  const [g0, g1, g2, g3, g4, g5, g6, g7] = groups;
+  const allZeroThrough = (until: number) =>
+    groups.slice(0, until).every((value) => value === 0);
+
+  // :: (unspecified) and ::1 (loopback)
+  if (allZeroThrough(7) && (g7 === 0 || g7 === 1)) {
+    return true;
+  }
+
+  // ::ffff:a.b.c.d — IPv4-mapped; defer to the IPv4 rules.
+  if (allZeroThrough(5) && g5 === 0xffff) {
+    return isBlockedIpv4(groupsToIpv4(g6, g7));
+  }
+
+  // 64:ff9b::/96 — NAT64; defer to the embedded IPv4.
+  if (g0 === 0x64 && g1 === 0xff9b && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0) {
+    return isBlockedIpv4(groupsToIpv4(g6, g7));
+  }
+
+  // 2002::/16 — 6to4; the next two groups embed an IPv4 address.
+  if (g0 === 0x2002) {
+    return isBlockedIpv4(groupsToIpv4(g1, g2));
+  }
+
+  // fc00::/7 (unique local), fe80::/10 (link-local), fec0::/10 (site-local)
+  if ((g0 & 0xfe00) === 0xfc00) {
+    return true;
+  }
+  if ((g0 & 0xffc0) === 0xfe80 || (g0 & 0xffc0) === 0xfec0) {
+    return true;
+  }
+
+  // ff00::/8 multicast, 2001:db8::/32 documentation
+  if ((g0 & 0xff00) === 0xff00) {
+    return true;
+  }
+  if (g0 === 0x2001 && g1 === 0x0db8) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Returns true when the IP address must never be dialled by a remote
+ * download: private, loopback, link-local, cloud-metadata, or otherwise
+ * non-public unicast space. Unparseable addresses are treated as blocked.
+ */
+export const isBlockedIpAddress = (ip: string): boolean => {
+  const trimmed = ip.trim().replace(/^\[|\]$/g, "");
+  const version = isIP(trimmed);
+
+  if (version === 4) {
+    return isBlockedIpv4(trimmed);
+  }
+  if (version === 6) {
+    return isBlockedIpv6(trimmed);
+  }
+  return true;
+};
+
+const normalizeHostRule = (rule: string): string =>
+  rule.trim().toLowerCase().replace(/\.$/, "");
+
+/**
+ * Matches a hostname against an allowlist entry. Entries are either exact
+ * hostnames ("assets.checkmedia.org") or wildcard suffixes
+ * ("*.checkmedia.org", which also matches the bare apex).
+ */
+export const isHostnameAllowed = (
+  hostname: string,
+  allowedHostnames: string[],
+): boolean => {
+  const normalizedHost = normalizeHostRule(hostname);
+
+  return allowedHostnames.some((rawRule) => {
+    const rule = normalizeHostRule(rawRule);
+    if (!rule) {
+      return false;
+    }
+
+    if (rule.startsWith("*.")) {
+      const suffix = rule.slice(2);
+      return (
+        normalizedHost === suffix || normalizedHost.endsWith(`.${suffix}`)
+      );
+    }
+
+    return normalizedHost === rule;
+  });
+};
+
+export class UnsafeRemoteUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeRemoteUrlError";
+  }
+}
+
+export type SafeRemoteUrlOptions = {
+  allowedHostnames?: string[];
+  requireHttps?: boolean;
+  /**
+   * Skips the blocked-address checks. ONLY for URLs the application built
+   * itself against its own configured origin (e.g. fetching its own media
+   * in development) — never for URLs that contain external input.
+   */
+  allowPrivateAddresses?: boolean;
+};
+
+/**
+ * Validates URL shape only (protocol, allowlist, credentials, IP-literal
+ * hosts). DNS-resolved addresses are validated separately via
+ * assertResolvesToPublicAddresses.
+ */
+export const assertSafeRemoteUrl = (
+  url: URL,
+  {
+    allowedHostnames,
+    requireHttps = true,
+    allowPrivateAddresses = false,
+  }: SafeRemoteUrlOptions = {},
+): void => {
+  if (requireHttps) {
+    if (url.protocol !== "https:") {
+      throw new UnsafeRemoteUrlError(
+        `Blocked non-HTTPS download URL: ${url.protocol}//${url.host}`,
+      );
+    }
+  } else if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new UnsafeRemoteUrlError(
+      `Blocked non-HTTP(S) download URL: ${url.protocol}`,
+    );
+  }
+
+  if (url.username || url.password) {
+    throw new UnsafeRemoteUrlError(
+      "Blocked download URL with embedded credentials",
+    );
+  }
+
+  const bareHostname = url.hostname.replace(/^\[|\]$/g, "");
+
+  if (allowedHostnames && allowedHostnames.length > 0) {
+    if (!isHostnameAllowed(url.hostname, allowedHostnames)) {
+      throw new UnsafeRemoteUrlError(
+        `Download host "${url.hostname}" is not in the configured allowlist`,
+      );
+    }
+  }
+
+  if (
+    !allowPrivateAddresses &&
+    isIP(bareHostname) !== 0 &&
+    isBlockedIpAddress(bareHostname)
+  ) {
+    throw new UnsafeRemoteUrlError(
+      `Download host resolves to a blocked address: ${bareHostname}`,
+    );
+  }
+};
+
+/**
+ * Resolves the hostname and rejects when any resolved address is
+ * non-public. IP-literal hostnames are validated directly.
+ */
+export const assertResolvesToPublicAddresses = async (
+  url: URL,
+  lookup: LookupFn = defaultLookup,
+): Promise<void> => {
+  const bareHostname = url.hostname.replace(/^\[|\]$/g, "");
+
+  if (isIP(bareHostname) !== 0) {
+    if (isBlockedIpAddress(bareHostname)) {
+      throw new UnsafeRemoteUrlError(
+        `Download host resolves to a blocked address: ${bareHostname}`,
+      );
+    }
+    return;
+  }
+
+  let resolved: LookupAddress[];
+  try {
+    const result = await lookup(bareHostname);
+    resolved = Array.isArray(result) ? result : [result];
+  } catch (error) {
+    throw new UnsafeRemoteUrlError(
+      `Failed to resolve download host "${bareHostname}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (resolved.length === 0) {
+    throw new UnsafeRemoteUrlError(
+      `Download host "${bareHostname}" did not resolve to any address`,
+    );
+  }
+
+  for (const { address } of resolved) {
+    if (isBlockedIpAddress(address)) {
+      throw new UnsafeRemoteUrlError(
+        `Download host "${bareHostname}" resolves to a blocked address: ${address}`,
+      );
+    }
+  }
+};
+
+/** Parses a comma-separated hostname allowlist from an env value. */
+export const parseHostnameAllowlist = (
+  value: string | null | undefined,
+): string[] =>
+  (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);

--- a/tests/int/fileSignature.int.spec.ts
+++ b/tests/int/fileSignature.int.spec.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  validateBufferSignature,
+  validateFileSignature,
+} from "@/utils/fileSignature";
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1]);
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 1, 2]);
+const GIF = Buffer.from("GIF89a-and-more");
+const WEBP = Buffer.concat([
+  Buffer.from("RIFF"),
+  Buffer.from([0x10, 0x00, 0x00, 0x00]),
+  Buffer.from("WEBPVP8 "),
+]);
+const PDF = Buffer.from("%PDF-1.7 rest of file");
+const DOCX = Buffer.from([0x50, 0x4b, 0x03, 0x04, 1, 2]);
+const DOC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1, 1]);
+
+describe("validateBufferSignature", () => {
+  it.each([
+    ["image/png", PNG],
+    ["image/jpeg", JPEG],
+    ["image/gif", GIF],
+    ["image/webp", WEBP],
+    ["application/pdf", PDF],
+    [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      DOCX,
+    ],
+    ["application/msword", DOC],
+    ["text/plain", Buffer.from("just some text")],
+    ["text/csv", Buffer.from("a,b,c\n1,2,3")],
+  ])("accepts a genuine %s file", (mimeType, header) => {
+    expect(validateBufferSignature(header, { mimeType })).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["image/png claimed but JPEG bytes", "image/png", JPEG],
+    ["image/jpeg claimed but PNG bytes", "image/jpeg", PNG],
+    ["pdf claimed but zip bytes", "application/pdf", DOCX],
+    ["png claimed but HTML", "image/png", Buffer.from("<html></html>")],
+    ["text claimed but binary", "text/plain", Buffer.from([0x00, 0x01, 0x02])],
+    ["text claimed but PDF bytes", "text/csv", PDF],
+  ])("rejects %s", (_label, mimeType, header) => {
+    const result = validateBufferSignature(header, { mimeType });
+    expect(result.ok).toBe(false);
+  });
+
+  it("falls back to the extension when no MIME type is claimed", () => {
+    expect(validateBufferSignature(JPEG, { extension: ".jpg" })).toEqual({
+      ok: true,
+    });
+    expect(
+      validateBufferSignature(Buffer.from("nope"), { extension: ".jpg" }).ok,
+    ).toBe(false);
+  });
+
+  it("passes types without a registered signature through", () => {
+    expect(
+      validateBufferSignature(Buffer.from("anything"), {
+        mimeType: "application/x-unknown",
+      }),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("validateFileSignature", () => {
+  const dirs: string[] = [];
+
+  afterAll(async () => {
+    for (const dir of dirs) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads the header from disk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sig-spec-"));
+    dirs.push(dir);
+    const genuine = join(dir, "real.png");
+    const spoofed = join(dir, "fake.png");
+    await writeFile(genuine, PNG);
+    await writeFile(spoofed, Buffer.from("MZ executable content"));
+
+    expect(
+      await validateFileSignature(genuine, { mimeType: "image/png" }),
+    ).toEqual({ ok: true });
+    expect(
+      (await validateFileSignature(spoofed, { mimeType: "image/png" })).ok,
+    ).toBe(false);
+  });
+});

--- a/tests/int/files.int.spec.ts
+++ b/tests/int/files.int.spec.ts
@@ -5,6 +5,16 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// downloadFile validates DNS resolution for every download; keep unit tests
+// hermetic by resolving every hostname to a public address unless a test
+// overrides the lookup explicitly.
+vi.mock("node:dns/promises", () => {
+  const lookup = vi.fn(async () => [
+    { address: "93.184.216.34", family: 4 },
+  ]);
+  return { default: { lookup }, lookup };
+});
+
 import {
   downloadFile,
   removeDownloadedFile,
@@ -14,6 +24,10 @@ import {
 
 const sha256 = (value: string) =>
   createHash("sha256").update(value).digest("hex");
+
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
 
 describe("sha256Buffer", () => {
   it("hashes buffer contents", () => {
@@ -114,5 +128,208 @@ describe("downloadFile", () => {
 
     expect(existsSync(filePath)).toBe(false);
     expect(existsSync(tempRoot)).toBe(true);
+  });
+
+  describe("SSRF protections", () => {
+    it("rejects plain HTTP URLs", async () => {
+      const fetchMock = vi.fn(async () => new Response("content"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        downloadFile("http://example.com/file.txt"),
+      ).rejects.toThrow(/non-HTTPS/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects URLs with embedded credentials", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => new Response("content")));
+
+      await expect(
+        downloadFile("https://user:pass@example.com/file.txt"),
+      ).rejects.toThrow(/embedded credentials/);
+    });
+
+    it.each([
+      ["loopback", "https://127.0.0.1/file"],
+      ["private 10/8", "https://10.0.0.8/file"],
+      ["private 192.168/16", "https://192.168.1.10/file"],
+      ["cloud metadata", "https://169.254.169.254/latest/meta-data/"],
+      ["IPv6 loopback", "https://[::1]/file"],
+      ["IPv4-mapped IPv6", "https://[::ffff:127.0.0.1]/file"],
+    ])("rejects %s IP-literal URLs", async (_label, url) => {
+      const fetchMock = vi.fn(async () => new Response("content"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(downloadFile(url)).rejects.toThrow(/blocked address/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects hostnames that resolve to private addresses", async () => {
+      const fetchMock = vi.fn(async () => new Response("content"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        downloadFile("https://internal.example.com/file", {
+          lookup: async () => [{ address: "10.1.2.3", family: 4 }],
+        }),
+      ).rejects.toThrow(/blocked address/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects hostnames where any resolved address is blocked", async () => {
+      const fetchMock = vi.fn(async () => new Response("content"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        downloadFile("https://dual.example.com/file", {
+          lookup: async () => [
+            { address: "93.184.216.34", family: 4 },
+            { address: "169.254.169.254", family: 4 },
+          ],
+        }),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it("rejects redirects that land on private addresses", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://10.0.0.5/internal" },
+          }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        downloadFile("https://example.com/file"),
+      ).rejects.toThrow(/blocked address/);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects redirects that downgrade to HTTP", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(null, {
+            status: 301,
+            headers: { location: "http://example.com/file" },
+          }),
+        ),
+      );
+
+      await expect(
+        downloadFile("https://example.com/file"),
+      ).rejects.toThrow(/non-HTTPS/);
+    });
+
+    it("bounds the number of redirects", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: URL) =>
+          new Response(null, {
+            status: 302,
+            headers: { location: `${url}x` },
+          }),
+        ),
+      );
+
+      await expect(
+        downloadFile("https://example.com/file", { maxRedirects: 2 }),
+      ).rejects.toThrow(/maximum of 2 redirects/);
+    });
+
+    it("follows safe redirects to completion", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://cdn.example.com/file.txt" },
+          }),
+        )
+        .mockResolvedValueOnce(new Response("redirected content"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const filePath = await downloadFile("https://example.com/file.txt");
+      downloadedPaths.push(filePath);
+
+      expect(await readFile(filePath, "utf8")).toBe("redirected content");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("applies the hostname allowlist to the initial URL", async () => {
+      const fetchMock = vi.fn(async () => new Response("content"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        downloadFile("https://evil.example.com/file", {
+          allowedHostnames: ["*.checkmedia.org"],
+        }),
+      ).rejects.toThrow(/not in the configured allowlist/);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      const filePath = await downloadFile(
+        "https://assets.checkmedia.org/file.txt",
+        { allowedHostnames: ["*.checkmedia.org"] },
+      );
+      downloadedPaths.push(filePath);
+      expect(await readFile(filePath, "utf8")).toBe("content");
+    });
+  });
+
+  describe("content validation", () => {
+    it("rejects downloads whose bytes do not match the content type", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response("<html>not an image</html>", {
+            headers: { "content-type": "image/png" },
+          }),
+        ),
+      );
+
+      await expect(
+        downloadFile("https://example.com/spoofed.png", {
+          verifySignature: true,
+        }),
+      ).rejects.toThrow(/failed content validation/);
+    });
+
+    it("accepts downloads whose bytes match the content type", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(
+            new Uint8Array([...PNG_HEADER, 0x00, 0x01, 0x02]),
+            { headers: { "content-type": "image/png" } },
+          ),
+        ),
+      );
+
+      const filePath = await downloadFile("https://example.com/real.png", {
+        verifySignature: true,
+      });
+      downloadedPaths.push(filePath);
+
+      expect(existsSync(filePath)).toBe(true);
+    });
+
+    it("rejects disallowed content types", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response("payload", {
+            headers: { "content-type": "text/html" },
+          }),
+        ),
+      );
+
+      await expect(
+        downloadFile("https://example.com/file", {
+          allowedMimeTypes: ["image/png", "image/jpeg"],
+        }),
+      ).rejects.toThrow(/Unsupported content-type/);
+    });
   });
 });

--- a/tests/int/meedanSyncRoute.int.spec.ts
+++ b/tests/int/meedanSyncRoute.int.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,17 +32,24 @@ const PROJECT_MEDIA_GLOBAL_ID = Buffer.from(
   "utf8",
 ).toString("base64");
 
-const buildRequest = (body: Record<string, unknown>): NextRequest =>
+const buildRequest = (
+  body: Record<string, unknown>,
+  { secret = SECRET }: { secret?: string } = {},
+): NextRequest =>
   new NextRequest("http://localhost:3000/api/meedan-sync", {
     body: JSON.stringify(body),
     headers: {
-      authorization: SECRET,
+      authorization: secret,
       "content-type": "application/json",
     },
     method: "POST",
   });
 
-const webhookBody = {
+// The route keeps a module-level idempotency cache keyed by the raw body, so
+// every test that expects fresh processing must use a unique body.
+const buildWebhookBody = (
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
   data: { id: "annotation-123" },
   object: {
     annotated_id: 456,
@@ -51,8 +59,10 @@ const webhookBody = {
       options: { title: "Updated title" },
       state: "published",
     },
+    ...overrides,
   },
-};
+  nonce: randomUUID(),
+});
 
 describe("meedan-sync webhook", () => {
   beforeEach(() => {
@@ -63,6 +73,15 @@ describe("meedan-sync webhook", () => {
       id,
       ...data,
     }));
+  });
+
+  it("rejects requests with a wrong secret", async () => {
+    const response = await POST(
+      buildRequest(buildWebhookBody(), { secret: "wrong-secret" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(findMock).not.toHaveBeenCalled();
   });
 
   it("does not overwrite an existing canonical meedanId", async () => {
@@ -76,7 +95,7 @@ describe("meedan-sync webhook", () => {
       ],
     });
 
-    const response = await POST(buildRequest(webhookBody));
+    const response = await POST(buildRequest(buildWebhookBody()));
 
     expect(response.status).toBe(200);
     expect(updateMock).toHaveBeenCalledTimes(1);
@@ -96,7 +115,7 @@ describe("meedan-sync webhook", () => {
       ],
     });
 
-    const response = await POST(buildRequest(webhookBody));
+    const response = await POST(buildRequest(buildWebhookBody()));
 
     expect(response.status).toBe(200);
     const updateData = updateMock.mock.calls[0][0].data;
@@ -120,7 +139,7 @@ describe("meedan-sync webhook", () => {
       ],
     });
 
-    const response = await POST(buildRequest(webhookBody));
+    const response = await POST(buildRequest(buildWebhookBody()));
 
     expect(response.status).toBe(200);
     expect(updateMock.mock.calls[0][0].id).toBe("promise-canonical");
@@ -129,9 +148,133 @@ describe("meedan-sync webhook", () => {
   it("returns 404 when no promise matches", async () => {
     findMock.mockResolvedValue({ docs: [] });
 
-    const response = await POST(buildRequest(webhookBody));
+    const response = await POST(buildRequest(buildWebhookBody()));
 
     expect(response.status).toBe(404);
     expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  describe("duplicate delivery / replay protection", () => {
+    it("replays the recorded response for a duplicate delivery without re-processing", async () => {
+      findMock.mockResolvedValue({
+        docs: [
+          {
+            id: "promise-1",
+            meedanId: PROJECT_MEDIA_GLOBAL_ID,
+            title: "Old title",
+          },
+        ],
+      });
+
+      const body = buildWebhookBody();
+
+      const first = await POST(buildRequest(body));
+      expect(first.status).toBe(200);
+      expect(updateMock).toHaveBeenCalledTimes(1);
+
+      const second = await POST(buildRequest(body));
+      expect(second.status).toBe(200);
+      const replayedBody = await second.json();
+      expect(replayedBody.replayed).toBe(true);
+      // The duplicate delivery did not update the promise again.
+      expect(updateMock).toHaveBeenCalledTimes(1);
+      expect(findMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still requires a valid secret to replay", async () => {
+      findMock.mockResolvedValue({
+        docs: [
+          {
+            id: "promise-1",
+            meedanId: PROJECT_MEDIA_GLOBAL_ID,
+            title: "Old title",
+          },
+        ],
+      });
+
+      const body = buildWebhookBody();
+      await POST(buildRequest(body));
+
+      const replayWithBadSecret = await POST(
+        buildRequest(body, { secret: "wrong" }),
+      );
+      expect(replayWithBadSecret.status).toBe(401);
+    });
+
+    it("rejects a concurrent duplicate while the original is in flight", async () => {
+      let resolveFind: (value: unknown) => void = () => {};
+      findMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFind = resolve;
+          }),
+      );
+
+      const body = buildWebhookBody();
+
+      const firstPromise = POST(buildRequest(body));
+      // Give the first request time to register as in-flight.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const second = await POST(buildRequest(body));
+      expect(second.status).toBe(409);
+
+      resolveFind({
+        docs: [
+          {
+            id: "promise-1",
+            meedanId: PROJECT_MEDIA_GLOBAL_ID,
+            title: "Old title",
+          },
+        ],
+      });
+      const first = await firstPromise;
+      expect(first.status).toBe(200);
+    });
+  });
+
+  describe("image URL hardening", () => {
+    beforeEach(() => {
+      findMock.mockResolvedValue({
+        docs: [
+          {
+            id: "promise-1",
+            meedanId: PROJECT_MEDIA_GLOBAL_ID,
+            title: "Old title",
+          },
+        ],
+      });
+    });
+
+    const bodyWithImage = (url: string) =>
+      buildWebhookBody({
+        file: [{ url }],
+      });
+
+    it("rejects image URLs on hosts outside the allowlist", async () => {
+      const response = await POST(
+        buildRequest(bodyWithImage("https://evil.example.com/img.png")),
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.error).toBe("Invalid image URL");
+    });
+
+    it("rejects plain HTTP image URLs", async () => {
+      const response = await POST(
+        buildRequest(bodyWithImage("http://assets.checkmedia.org/img.png")),
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects image URLs pointing at cloud metadata addresses", async () => {
+      const response = await POST(
+        buildRequest(bodyWithImage("https://169.254.169.254/latest/meta-data")),
+      );
+
+      expect(response.status).toBe(400);
+    });
   });
 });

--- a/tests/int/requestGuards.int.spec.ts
+++ b/tests/int/requestGuards.int.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createByteBudget,
+  createConcurrencyGate,
+  createIdempotencyCache,
+  createRateLimiter,
+  safeCompare,
+} from "@/utils/requestGuards";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("safeCompare", () => {
+  it("compares equal strings", () => {
+    expect(safeCompare("secret-token", "secret-token")).toBe(true);
+  });
+
+  it("rejects different strings and lengths", () => {
+    expect(safeCompare("secret-token", "secret-tokem")).toBe(false);
+    expect(safeCompare("short", "longer-value")).toBe(false);
+    expect(safeCompare("", "x")).toBe(false);
+  });
+});
+
+describe("createRateLimiter", () => {
+  it("allows up to the limit per window, then blocks", () => {
+    const limiter = createRateLimiter({ limit: 3, windowMs: 60_000 });
+
+    expect(limiter.allow("ip-1")).toBe(true);
+    expect(limiter.allow("ip-1")).toBe(true);
+    expect(limiter.allow("ip-1")).toBe(true);
+    expect(limiter.allow("ip-1")).toBe(false);
+    // Other callers are tracked independently.
+    expect(limiter.allow("ip-2")).toBe(true);
+  });
+
+  it("resets after the window elapses", () => {
+    vi.useFakeTimers();
+    const limiter = createRateLimiter({ limit: 1, windowMs: 1_000 });
+
+    expect(limiter.allow("ip-1")).toBe(true);
+    expect(limiter.allow("ip-1")).toBe(false);
+
+    vi.advanceTimersByTime(1_001);
+    expect(limiter.allow("ip-1")).toBe(true);
+  });
+});
+
+describe("createIdempotencyCache", () => {
+  it("tracks new, in-flight, and replayed requests", () => {
+    const cache = createIdempotencyCache({ ttlMs: 60_000 });
+
+    expect(cache.begin("key-1")).toEqual({ state: "new" });
+    expect(cache.begin("key-1")).toEqual({ state: "in-flight" });
+
+    cache.complete("key-1", { status: 200, body: { ok: true } });
+
+    expect(cache.begin("key-1")).toEqual({
+      state: "replay",
+      record: { status: 200, body: { ok: true } },
+    });
+  });
+
+  it("re-admits a request after release (failed processing)", () => {
+    const cache = createIdempotencyCache({ ttlMs: 60_000 });
+
+    expect(cache.begin("key-1")).toEqual({ state: "new" });
+    cache.release("key-1");
+    expect(cache.begin("key-1")).toEqual({ state: "new" });
+  });
+
+  it("expires records after the TTL", () => {
+    vi.useFakeTimers();
+    const cache = createIdempotencyCache({ ttlMs: 1_000 });
+
+    cache.begin("key-1");
+    cache.complete("key-1", { status: 200, body: { ok: true } });
+
+    vi.advanceTimersByTime(1_001);
+    expect(cache.begin("key-1")).toEqual({ state: "new" });
+  });
+
+  it("evicts the oldest entries beyond maxEntries", () => {
+    const cache = createIdempotencyCache({ ttlMs: 60_000, maxEntries: 2 });
+
+    cache.begin("key-1");
+    cache.complete("key-1", { status: 200, body: {} });
+    cache.begin("key-2");
+    cache.begin("key-3");
+
+    // key-1 was evicted to stay within budget, so it is treated as new.
+    expect(cache.begin("key-1")).toEqual({ state: "new" });
+  });
+});
+
+describe("createConcurrencyGate", () => {
+  it("bounds simultaneous holders and releases slots", () => {
+    const gate = createConcurrencyGate(2);
+
+    const first = gate.tryAcquire();
+    const second = gate.tryAcquire();
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(gate.tryAcquire()).toBeNull();
+
+    first?.();
+    expect(gate.tryAcquire()).not.toBeNull();
+  });
+
+  it("ignores double release", () => {
+    const gate = createConcurrencyGate(1);
+    const release = gate.tryAcquire();
+    release?.();
+    release?.();
+
+    const again = gate.tryAcquire();
+    expect(again).not.toBeNull();
+    expect(gate.tryAcquire()).toBeNull();
+  });
+});
+
+describe("createByteBudget", () => {
+  it("caps consumption within the window", () => {
+    const budget = createByteBudget({ maxBytes: 100 });
+
+    expect(budget.tryConsume(60)).toBe(true);
+    expect(budget.tryConsume(60)).toBe(false);
+    expect(budget.tryConsume(40)).toBe(true);
+    expect(budget.tryConsume(1)).toBe(false);
+  });
+
+  it("resets after the window", () => {
+    vi.useFakeTimers();
+    const budget = createByteBudget({ maxBytes: 100, windowMs: 1_000 });
+
+    expect(budget.tryConsume(100)).toBe(true);
+    expect(budget.tryConsume(1)).toBe(false);
+
+    vi.advanceTimersByTime(1_001);
+    expect(budget.tryConsume(100)).toBe(true);
+  });
+});

--- a/tests/int/ssrf.int.spec.ts
+++ b/tests/int/ssrf.int.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertResolvesToPublicAddresses,
+  assertSafeRemoteUrl,
+  isBlockedIpAddress,
+  isHostnameAllowed,
+  parseHostnameAllowlist,
+} from "@/utils/ssrf";
+
+describe("isBlockedIpAddress", () => {
+  it.each([
+    "0.0.0.0",
+    "10.0.0.1",
+    "100.64.0.1",
+    "127.0.0.1",
+    "127.255.255.255",
+    "169.254.169.254",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.0.0.1",
+    "192.168.0.1",
+    "198.18.0.1",
+    "224.0.0.1",
+    "255.255.255.255",
+    "::",
+    "::1",
+    "::ffff:127.0.0.1",
+    "::ffff:10.0.0.1",
+    "64:ff9b::a00:1",
+    "fe80::1",
+    "fc00::1",
+    "fd12:3456::1",
+    "ff02::1",
+    "2001:db8::1",
+    "2002:7f00:0001::",
+    "not-an-ip",
+  ])("blocks %s", (ip) => {
+    expect(isBlockedIpAddress(ip)).toBe(true);
+  });
+
+  it.each([
+    "93.184.216.34",
+    "8.8.8.8",
+    "196.216.167.10",
+    "172.32.0.1",
+    "2606:4700::6810:85e5",
+    "2a00:1450:4009:81f::200e",
+  ])("allows public address %s", (ip) => {
+    expect(isBlockedIpAddress(ip)).toBe(false);
+  });
+});
+
+describe("isHostnameAllowed", () => {
+  it("matches exact hostnames case-insensitively", () => {
+    expect(isHostnameAllowed("Assets.CheckMedia.org", ["assets.checkmedia.org"])).toBe(
+      true,
+    );
+    expect(isHostnameAllowed("assets.checkmedia.org", ["checkmedia.org"])).toBe(
+      false,
+    );
+  });
+
+  it("matches wildcard suffixes including the apex", () => {
+    expect(isHostnameAllowed("assets.checkmedia.org", ["*.checkmedia.org"])).toBe(
+      true,
+    );
+    expect(isHostnameAllowed("checkmedia.org", ["*.checkmedia.org"])).toBe(true);
+    expect(
+      isHostnameAllowed("evilcheckmedia.org", ["*.checkmedia.org"]),
+    ).toBe(false);
+    expect(
+      isHostnameAllowed("checkmedia.org.evil.com", ["*.checkmedia.org"]),
+    ).toBe(false);
+  });
+});
+
+describe("assertSafeRemoteUrl", () => {
+  it("requires HTTPS by default", () => {
+    expect(() =>
+      assertSafeRemoteUrl(new URL("http://example.com/file")),
+    ).toThrow(/non-HTTPS/);
+  });
+
+  it("rejects blocked IP literals", () => {
+    expect(() =>
+      assertSafeRemoteUrl(new URL("https://169.254.169.254/creds")),
+    ).toThrow(/blocked address/);
+  });
+
+  it("enforces the allowlist when provided", () => {
+    expect(() =>
+      assertSafeRemoteUrl(new URL("https://example.com/file"), {
+        allowedHostnames: ["*.checkmedia.org"],
+      }),
+    ).toThrow(/allowlist/);
+
+    expect(() =>
+      assertSafeRemoteUrl(new URL("https://assets.checkmedia.org/img.png"), {
+        allowedHostnames: ["*.checkmedia.org"],
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("assertResolvesToPublicAddresses", () => {
+  it("accepts hosts resolving only to public addresses", async () => {
+    await expect(
+      assertResolvesToPublicAddresses(new URL("https://example.com"), async () => [
+        { address: "93.184.216.34", family: 4 },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects hosts resolving to any blocked address", async () => {
+    await expect(
+      assertResolvesToPublicAddresses(new URL("https://example.com"), async () => [
+        { address: "93.184.216.34", family: 4 },
+        { address: "10.0.0.1", family: 4 },
+      ]),
+    ).rejects.toThrow(/blocked address/);
+  });
+
+  it("rejects hosts that fail to resolve", async () => {
+    await expect(
+      assertResolvesToPublicAddresses(new URL("https://example.com"), async () => {
+        throw new Error("ENOTFOUND");
+      }),
+    ).rejects.toThrow(/Failed to resolve/);
+  });
+});
+
+describe("parseHostnameAllowlist", () => {
+  it("splits and trims comma-separated entries", () => {
+    expect(parseHostnameAllowlist(" a.com , *.b.org ,, ")).toEqual([
+      "a.com",
+      "*.b.org",
+    ]);
+    expect(parseHostnameAllowlist(undefined)).toEqual([]);
+  });
+});

--- a/tests/int/uploadValidation.int.spec.ts
+++ b/tests/int/uploadValidation.int.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inferUploadKindFromMetadata,
+  validateUploadMetadata,
+} from "@/app/api/airtable-upload/utils";
+
+describe("validateUploadMetadata", () => {
+  it("accepts consistent extension + MIME pairs", () => {
+    expect(
+      validateUploadMetadata(
+        { fileName: "report.pdf", mimeType: "application/pdf" },
+        "document",
+      ),
+    ).toEqual({ ok: true });
+    expect(
+      validateUploadMetadata(
+        { fileName: "photo.jpg", mimeType: "image/jpeg" },
+        "entityImage",
+      ),
+    ).toEqual({ ok: true });
+    expect(
+      validateUploadMetadata(
+        { fileName: "data.csv", mimeType: "text/csv" },
+        "document",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a MIME type that does not match the extension", () => {
+    const result = validateUploadMetadata(
+      { fileName: "photo.png", mimeType: "image/jpeg" },
+      "entityImage",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(415);
+      expect(result.message).toMatch(/does not match/);
+    }
+  });
+
+  it("rejects files with only one valid signal (extension or MIME)", () => {
+    // Allowed extension but missing/foreign MIME type.
+    expect(
+      validateUploadMetadata(
+        { fileName: "report.pdf", mimeType: "application/octet-stream" },
+        "document",
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateUploadMetadata({ fileName: "report.pdf" }, "document").ok,
+    ).toBe(false);
+    // Allowed MIME type but extension-less/foreign filename.
+    expect(
+      validateUploadMetadata(
+        { fileName: "report", mimeType: "application/pdf" },
+        "document",
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateUploadMetadata(
+        { fileName: "report.exe", mimeType: "application/pdf" },
+        "document",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("rejects SVG uploads entirely", () => {
+    expect(
+      validateUploadMetadata(
+        { fileName: "logo.svg", mimeType: "image/svg+xml" },
+        "entityImage",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("rejects a document masquerading as an image kind and vice versa", () => {
+    expect(
+      validateUploadMetadata(
+        { fileName: "report.pdf", mimeType: "application/pdf" },
+        "entityImage",
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateUploadMetadata(
+        { fileName: "photo.png", mimeType: "image/png" },
+        "document",
+      ).ok,
+    ).toBe(false);
+  });
+});
+
+describe("inferUploadKindFromMetadata", () => {
+  it("infers the kind when the metadata is unambiguous", () => {
+    expect(
+      inferUploadKindFromMetadata({
+        fileName: "report.pdf",
+        mimeType: "application/pdf",
+      }),
+    ).toBe("document");
+    expect(
+      inferUploadKindFromMetadata({
+        fileName: "photo.webp",
+        mimeType: "image/webp",
+      }),
+    ).toBe("entityImage");
+  });
+
+  it("returns null for metadata valid for no kind", () => {
+    expect(
+      inferUploadKindFromMetadata({
+        fileName: "script.sh",
+        mimeType: "text/x-shellscript",
+      }),
+    ).toBeNull();
+    expect(
+      inferUploadKindFromMetadata({
+        fileName: "logo.svg",
+        mimeType: "image/svg+xml",
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #573

## What this does

Creates a safe boundary for Meedan remote downloads and Airtable uploads, and adds abuse controls to state-changing inbound endpoints.

### Remote downloads (`src/utils/files.ts`, `src/utils/ssrf.ts`)
- **HTTPS required** for all remote downloads; Meedan image URLs must additionally match the `MEEDAN_ALLOWED_IMAGE_HOSTS` allowlist (default `checkmedia.org,*.checkmedia.org`), applied in both the webhook route and the workflow sync.
- **SSRF filtering**: private, loopback, link-local (incl. `169.254.169.254` metadata), CGNAT, multicast, reserved, and IPv6-equivalent (mapped/NAT64/6to4/ULA) addresses are rejected for IP-literal hosts, for every DNS result, and for **every redirect destination** (redirects are followed manually and re-validated per hop).
- **Bounded**: max redirects (`DOWNLOAD_MAX_REDIRECTS`, default 3), response-header timeout per hop (30s), total download deadline (5min), streaming byte limit, and a per-instance download concurrency semaphore (default 4).

### Uploads (`/api/airtable-upload`)
- Extension and MIME metadata must both be allowed for the upload kind **and agree with each other**, and the file's magic bytes must match the claimed type (`src/utils/fileSignature.ts`) — spoofed files are rejected with 415.
- **SVG removed** from every ingestion path (uploads and Meedan images). Locally served media (`/api/media/file/*`) now gets `X-Content-Type-Options: nosniff` and a sandboxing CSP.
- Per-IP rate limit, per-instance concurrency gate, and a rolling daily byte budget bound storage/cost from a leaked token.

### Inbound endpoints
- Meedan webhook secret is now compared in **constant time** (shared `safeCompare`, also used by the upload token check).
- **Replay/idempotency**: request bodies are fingerprinted (SHA-256); duplicates of completed requests replay the recorded response without re-processing, in-flight duplicates get 409, and 5xx outcomes stay retryable.
- Webhook rate limiting per client IP.

### Docs
Quotas, env vars, deployment notes (per-instance guard semantics), and residual-risk notes are documented in `docs/remote-file-ingestion.md`; `.env.example` updated.

## Behaviour changes to be aware of
- Plain-HTTP document links from Airtable are now rejected (the task marks the row failed so editors can fix the link).
- SVG uploads/images are no longer accepted anywhere.
- `extractDocuments` keeps fetching the app's own media from `NEXT_PUBLIC_APP_URL` via an explicit internal-only exception.

## Testing
- 149 integration tests pass (14 files), including ~80 new tests covering: SSRF variants (IP literals, DNS to private ranges, metadata endpoint, mapped IPv6), redirect bounding/downgrades/private destinations, hostname allowlisting, spoofed file signatures, extension/MIME mismatches, oversized files, rate limiting, and webhook replay + duplicate/concurrent delivery.
- Lint passes; no new type errors (pre-existing `Share.tsx` errors untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)