### PR TITLE
Fix public route and entity resolution invariants

### DIFF
--- a/migrations/20260720_000000_check_political_entity_slug_uniqueness.ts
+++ b/migrations/20260720_000000_check_political_entity_slug_uniqueness.ts
@@ -1,0 +1,59 @@
+import type { MigrateUpArgs } from "@payloadcms/db-mongodb";
+
+/**
+ * Political-entity slugs must be unique per tenant (enforced going forward by
+ * the `ensureUniqueSlug` beforeValidate hook). This migration verifies no
+ * pre-existing duplicates violate that invariant; it fails loudly so an
+ * operator resolves the conflicting slugs before deploying, since duplicate
+ * slugs make public entity resolution ambiguous.
+ */
+export async function up({ payload }: MigrateUpArgs): Promise<void> {
+  const { docs } = await payload.find({
+    collection: "political-entities",
+    pagination: false,
+    depth: 0,
+    overrideAccess: true,
+  });
+
+  const entitiesByKey = new Map<string, string[]>();
+
+  for (const doc of docs) {
+    if (!doc.slug) {
+      continue;
+    }
+    const tenantId =
+      typeof doc.tenant === "string"
+        ? doc.tenant
+        : (doc.tenant?.id ?? "no-tenant");
+    const key = `${tenantId}:${doc.slug}`;
+    const entries = entitiesByKey.get(key) ?? [];
+    entries.push(`${doc.name ?? "unnamed"} (${doc.id})`);
+    entitiesByKey.set(key, entries);
+  }
+
+  const duplicates = [...entitiesByKey.entries()].filter(
+    ([, entries]) => entries.length > 1,
+  );
+
+  if (duplicates.length > 0) {
+    const details = duplicates
+      .map(
+        ([key, entries]) =>
+          `  ${key}: ${entries.join(", ")}`,
+      )
+      .join("\n");
+
+    throw new Error(
+      `Duplicate political-entity slugs detected (tenant:slug). ` +
+        `Resolve these before migrating:\n${details}`,
+    );
+  }
+
+  payload.logger.info(
+    "check_political_entity_slug_uniqueness:: no duplicate slugs found",
+  );
+}
+
+export async function down(): Promise<void> {
+  // Verification-only migration; nothing to revert.
+}

--- a/src/app/(frontend)/[...slugs]/page.tsx
+++ b/src/app/(frontend)/[...slugs]/page.tsx
@@ -20,6 +20,10 @@ import {
   getPageSeo,
   resolveTenantSeoContext,
 } from "@/lib/seo";
+import {
+  resolveGlobalRoute,
+  resolvePublicRoute,
+} from "@/lib/routes/publicRoutes";
 import { resolveTenantLocale } from "@/utils/locales";
 import { resolveBrowserLocale } from "@/lib/locale";
 import type { EntityPage } from "@/payload-types";
@@ -222,8 +226,16 @@ export default async function Page(params: Args) {
   const slugs = paramsValue?.slugs ?? [];
 
   if (!tenant) {
-    const pageSlug = slugs[0] ?? "index";
-    const globalPage = await queryGlobalPageBySlug({ slug: pageSlug, locale });
+    const globalRoute = resolveGlobalRoute(slugs);
+
+    if (globalRoute.type === "not-found") {
+      return notFound();
+    }
+
+    const globalPage = await queryGlobalPageBySlug({
+      slug: globalRoute.pageSlug,
+      locale,
+    });
 
     if (!globalPage) {
       return notFound();
@@ -245,124 +257,16 @@ export default async function Page(params: Args) {
     );
   }
 
-  const [maybePoliticalEntitySlug, pageSlugCandidate] = slugs;
-
   const politicalEntities = await getPoliticalEntitiesByTenant(tenant, locale);
+  const resolution = resolvePublicRoute(slugs, politicalEntities);
 
-  const politicalEntity = politicalEntities.find(
-    (entity) => entity.slug === maybePoliticalEntitySlug
-  );
+  if (resolution.type === "not-found") {
+    return notFound();
+  }
+
   const payload = await getGlobalPayload();
 
-  if (!politicalEntity) {
-    const hasExplicitPageSlug =
-      Boolean(pageSlugCandidate) || Boolean(maybePoliticalEntitySlug);
-
-    if (!hasExplicitPageSlug) {
-      const entityPageSettings = await payload.findGlobal({
-        slug: "entity-page",
-        locale,
-      });
-      const entityBlocks = entityPageSettings?.entitySelector?.blocks ?? [];
-
-      const entityNavMenus =
-        (entityPageSettings?.primaryNavigation?.menus || [])
-          .map((m) => toMenuLink(m?.link ?? m))
-          .filter((x: MenuLink | null): x is MenuLink => Boolean(x)) || [];
-
-      const entitySecondaryNavColumns =
-        (entityPageSettings?.secondaryNavigationList || [])
-          .map((entry) => {
-            const menus = entry?.secondaryNavigation?.menus || [];
-            const links = menus
-              .map((m) => toMenuLink(m?.link ?? m))
-              .filter((x: MenuLink | null): x is MenuLink => Boolean(x));
-            if (!entry?.secondaryNavigation?.titles && links.length === 0) {
-              return null;
-            }
-            return {
-              title: entry?.secondaryNavigation?.titles || null,
-              links,
-            };
-          })
-          .filter((col): col is { title: string | null; links: MenuLink[] } =>
-            Boolean(col)
-          ) || [];
-
-      const navigationForEntity = { ...navigation, menus: entityNavMenus };
-
-      const footerForTenant =
-        entitySecondaryNavColumns.length > 0
-          ? { ...footer, secondaryNavColumns: entitySecondaryNavColumns }
-          : footer;
-
-      return (
-        <>
-          <Navigation
-            title={title}
-            {...navigationForEntity}
-            tenantSelectionHref={tenantSelectionHref}
-          />
-          <Suspense>
-            <BlockRenderer blocks={entityBlocks} />
-          </Suspense>
-          <Footer title={title} description={description} {...footerForTenant} />
-        </>
-      );
-    }
-
-    const fallbackPageSlug =
-      pageSlugCandidate ?? maybePoliticalEntitySlug ?? "index";
-
-    const tenantPage = await queryPageBySlug({
-      slug: fallbackPageSlug,
-      tenant,
-      locale,
-    });
-
-    if (tenantPage) {
-      return (
-        <>
-          <Navigation
-            title={title}
-            {...navigation}
-            tenantName={tenant?.name ?? null}
-            tenantSelectionHref={tenantSelectionHref}
-            tenantFlag={tenant?.flag ?? null}
-            tenantFlagLabel={tenant?.name ?? tenant?.country ?? null}
-          />
-          <Suspense>
-            <BlockRenderer blocks={tenantPage.blocks} />
-          </Suspense>
-          <Footer title={title} description={description} {...footer} />
-        </>
-      );
-    }
-
-    const globalPage = await queryGlobalPageBySlug({
-      slug: fallbackPageSlug,
-      locale,
-    });
-
-    if (globalPage) {
-      return (
-        <>
-          <Navigation
-            title={title}
-            {...navigation}
-            tenantName={tenant?.name ?? null}
-            tenantSelectionHref={tenantSelectionHref}
-            tenantFlag={tenant?.flag ?? null}
-            tenantFlagLabel={tenant?.name ?? tenant?.country ?? null}
-          />
-          <Suspense>
-            <BlockRenderer blocks={globalPage.blocks} />
-          </Suspense>
-          <Footer title={title} description={description} {...footer} />
-        </>
-      );
-    }
-
+  if (resolution.type === "entity-selector") {
     const entityPageSettings = await payload.findGlobal({
       slug: "entity-page",
       locale,
@@ -415,7 +319,61 @@ export default async function Page(params: Args) {
     );
   }
 
-  const tenantPageSlug = pageSlugCandidate ?? "index";
+  if (resolution.type === "tenant-page") {
+    const tenantPage = await queryPageBySlug({
+      slug: resolution.pageSlug,
+      tenant,
+      locale,
+    });
+
+    if (tenantPage) {
+      return (
+        <>
+          <Navigation
+            title={title}
+            {...navigation}
+            tenantName={tenant?.name ?? null}
+            tenantSelectionHref={tenantSelectionHref}
+            tenantFlag={tenant?.flag ?? null}
+            tenantFlagLabel={tenant?.name ?? tenant?.country ?? null}
+          />
+          <Suspense>
+            <BlockRenderer blocks={tenantPage.blocks} />
+          </Suspense>
+          <Footer title={title} description={description} {...footer} />
+        </>
+      );
+    }
+
+    const globalPage = await queryGlobalPageBySlug({
+      slug: resolution.pageSlug,
+      locale,
+    });
+
+    if (globalPage) {
+      return (
+        <>
+          <Navigation
+            title={title}
+            {...navigation}
+            tenantName={tenant?.name ?? null}
+            tenantSelectionHref={tenantSelectionHref}
+            tenantFlag={tenant?.flag ?? null}
+            tenantFlagLabel={tenant?.name ?? tenant?.country ?? null}
+          />
+          <Suspense>
+            <BlockRenderer blocks={globalPage.blocks} />
+          </Suspense>
+          <Footer title={title} description={description} {...footer} />
+        </>
+      );
+    }
+
+    return notFound();
+  }
+
+  const politicalEntity = resolution.entity;
+  const tenantPageSlug = resolution.pageSlug;
 
   const page = await queryPageBySlug({
     slug: tenantPageSlug,

--- a/src/app/(frontend)/error.tsx
+++ b/src/app/(frontend)/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { Box, Button, Container, Typography } from "@mui/material";
+
+export default function FrontendError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <Container maxWidth="md">
+      <Box
+        sx={{
+          minHeight: "70vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          textAlign: "center",
+          gap: 2,
+          py: 8,
+        }}
+      >
+        <Typography variant="h4" component="h1">
+          Something went wrong
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          An unexpected error occurred while loading this page. Please try
+          again.
+        </Typography>
+        <Button onClick={reset} variant="contained" sx={{ mt: 2 }}>
+          Try again
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Box, Button, Container, Typography } from "@mui/material";
+
+export const metadata: Metadata = {
+  title: "Page not found | PromiseTracker",
+};
+
+export default function NotFound() {
+  return (
+    <Container maxWidth="md">
+      <Box
+        sx={{
+          minHeight: "70vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          textAlign: "center",
+          gap: 2,
+          py: 8,
+        }}
+      >
+        <Typography variant="h1" component="p" sx={{ fontWeight: 700 }}>
+          404
+        </Typography>
+        <Typography variant="h4" component="h1">
+          Page not found
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          The page you are looking for does not exist or may have been moved.
+        </Typography>
+        <Button component={Link} href="/" variant="contained" sx={{ mt: 2 }}>
+          Go to the homepage
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/src/components/BlockRenderer.tsx
+++ b/src/components/BlockRenderer.tsx
@@ -71,7 +71,7 @@ export const BlockRenderer = ({ blocks, entity }: BlockProps) => {
             if (Block) {
               return (
                 <div key={String(key)}>
-                  <Block {...block} entitySlug={entity?.slug} />
+                  <Block {...block} entitySlug={entity?.slug} entity={entity} />
                 </div>
               );
             }

--- a/src/components/LatestPromises/index.tsx
+++ b/src/components/LatestPromises/index.tsx
@@ -1,79 +1,53 @@
 import LatestPromises from "./LatestPromises";
-import { LatestPromisesBlock } from "@/payload-types";
+import { LatestPromisesBlock, PoliticalEntity } from "@/payload-types";
 
 import { getGlobalPayload } from "@/lib/payload";
 import { getPromiseUpdateEmbed } from "@/lib/data/promiseUpdates";
+import { getPoliticalEntityBySlug } from "@/lib/data/politicalEntities";
+import { buildPublishedPromisesQuery } from "@/lib/data/promiseQueries";
 import { getTenantBySubDomain } from "@/lib/data/tenants";
 import { getDomain } from "@/lib/domain";
-import { resolveTenantLocale } from "@/utils/locales";
-import { resolveBrowserLocale } from "@/lib/locale";
+import { resolveEntityLocale, resolveTenantLocale } from "@/utils/locales";
 
 export type LatestPromisesProps = LatestPromisesBlock & {
   entitySlug: string;
+  entity?: PoliticalEntity;
 };
 
 export default async function Index({
   entitySlug,
+  entity: resolvedEntity,
   title,
   seeAllLink,
 }: LatestPromisesProps) {
-  if (!entitySlug) {
+  if (!resolvedEntity && !entitySlug) {
     return null;
   }
   const payload = await getGlobalPayload();
-  const { subdomain } = await getDomain();
-  const tenant = await getTenantBySubDomain(subdomain);
-  const locale = tenant
-    ? resolveTenantLocale(tenant)
-    : await resolveBrowserLocale();
 
-  const entityQuery = await payload.find({
-    collection: "political-entities",
-    where: {
-      and: [
-        {
-          slug: {
-            equals: entitySlug,
-          },
-        },
-        {
-          publish: {
-            equals: true,
-          },
-        },
-      ],
-    },
-    limit: 1,
-    depth: 2,
-    locale,
-  });
-
-  const entity = entityQuery.docs[0];
+  // Prefer the entity the route already resolved — never re-resolve by slug
+  // alone, since slugs are only unique per tenant.
+  let entity = resolvedEntity;
+  if (!entity) {
+    const { subdomain } = await getDomain();
+    const tenant = await getTenantBySubDomain(subdomain);
+    if (!tenant) {
+      return null;
+    }
+    entity = await getPoliticalEntityBySlug(
+      tenant,
+      entitySlug,
+      resolveTenantLocale(tenant),
+    );
+  }
 
   if (!entity) {
     return null;
   }
-  const { docs } = await payload.find({
-    collection: "promises",
-    where: {
-      and: [
-        {
-          politicalEntity: {
-            equals: entity.id,
-          },
-        },
-        {
-          publishStatus: {
-            equals: "published",
-          },
-        },
-      ],
-    },
-    depth: 2,
-    limit: 3,
-    sort: "-createdAt",
-    locale,
-  });
+  const locale = resolveEntityLocale(entity);
+  const { docs } = await payload.find(
+    buildPublishedPromisesQuery(entity.id, { limit: 3, locale }),
+  );
 
   if (!docs || docs.length === 0) {
     return null;

--- a/src/components/Promises/index.tsx
+++ b/src/components/Promises/index.tsx
@@ -1,12 +1,40 @@
 import { getGlobalPayload } from "@/lib/payload";
 import Promises from "./Promises";
 import { slugify } from "@/utils/utils";
-import { PromiseListBlock } from "@/payload-types";
+import { PoliticalEntity, PromiseListBlock } from "@/payload-types";
 import { resolveEntityLocale } from "@/utils/locales";
 import { getPromiseUpdateEmbed } from "@/lib/data/promiseUpdates";
+import { getPoliticalEntityBySlug } from "@/lib/data/politicalEntities";
+import { buildPublishedPromisesQuery } from "@/lib/data/promiseQueries";
+import { getTenantBySubDomain } from "@/lib/data/tenants";
+import { getDomain } from "@/lib/domain";
 
 export type PromiseListProps = PromiseListBlock & {
   entitySlug?: string;
+  entity?: PoliticalEntity;
+};
+
+const resolveEntity = async (
+  entity: PoliticalEntity | undefined,
+  entitySlug: string | undefined,
+): Promise<PoliticalEntity | undefined> => {
+  // Prefer the entity the route already resolved — never re-resolve by slug
+  // alone, since slugs are only unique per tenant.
+  if (entity) {
+    return entity;
+  }
+
+  if (!entitySlug) {
+    return undefined;
+  }
+
+  const { subdomain } = await getDomain();
+  const tenant = await getTenantBySubDomain(subdomain);
+  if (!tenant) {
+    return undefined;
+  }
+
+  return getPoliticalEntityBySlug(tenant, entitySlug);
 };
 
 async function Index(props: PromiseListProps) {
@@ -14,27 +42,7 @@ async function Index(props: PromiseListProps) {
     props;
   const payload = await getGlobalPayload();
 
-  const entityQuery = await payload.find({
-    collection: "political-entities",
-    where: {
-      and: [
-        {
-          slug: {
-            equals: entitySlug,
-          },
-        },
-        {
-          publish: {
-            equals: true,
-          },
-        },
-      ],
-    },
-    limit: 1,
-    depth: 2,
-  });
-
-  const entity = entityQuery.docs[0];
+  const entity = await resolveEntity(props.entity, entitySlug);
 
   if (!entity) {
     return null;
@@ -43,26 +51,11 @@ async function Index(props: PromiseListProps) {
   const promiseUpdateSettings = await getPromiseUpdateEmbed();
   const fallbackImage = promiseUpdateSettings?.defaultImage ?? null;
 
-  const { docs } = await payload.find({
-    collection: "promises",
-    where: {
-      and: [
-        {
-          politicalEntity: {
-            equals: entity.id,
-          },
-        },
-        {
-          publishStatus: {
-            equals: "published",
-          },
-        },
-      ],
-    },
-    depth: 2,
-    sort: "-createdAt",
-    locale,
-  });
+  // Deliberately unpaginated: the main promise list renders every published
+  // promise for the entity (client-side filtering handles navigation).
+  const { docs } = await payload.find(
+    buildPublishedPromisesQuery(entity.id, { locale }),
+  );
 
   if (!docs || docs.length === 0) {
     return null;

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -34,8 +34,13 @@ export const slugField: Slug = (fieldToUse = "title", overrides = {}) => {
     label: "Slug",
     ...(slugOverrides || {}),
     hooks: {
-      // Kept this in for hook or API based updates
-      beforeValidate: [formatSlugHook(fieldToUse)],
+      ...(slugOverrides?.hooks || {}),
+      // Kept this in for hook or API based updates. Hooks passed via
+      // slugOverrides (e.g. uniqueness guards) must run after formatting.
+      beforeValidate: [
+        formatSlugHook(fieldToUse),
+        ...(slugOverrides?.hooks?.beforeValidate ?? []),
+      ],
     },
     admin: {
       position: "sidebar",

--- a/src/lib/data/promiseQueries.ts
+++ b/src/lib/data/promiseQueries.ts
@@ -1,0 +1,40 @@
+import type { Where } from "payload";
+
+type PublishedPromisesQueryOptions = {
+  /**
+   * Maximum number of records to return. When omitted, pagination is
+   * deliberately disabled so lists render every published promise for the
+   * entity rather than silently truncating at Payload's default page size.
+   */
+  limit?: number;
+  locale?: "en" | "fr";
+};
+
+export const buildPublishedPromisesQuery = (
+  entityId: string,
+  { limit, locale }: PublishedPromisesQueryOptions = {},
+) => {
+  const where: Where = {
+    and: [
+      {
+        politicalEntity: {
+          equals: entityId,
+        },
+      },
+      {
+        publishStatus: {
+          equals: "published",
+        },
+      },
+    ],
+  };
+
+  return {
+    collection: "promises" as const,
+    where,
+    depth: 2,
+    sort: "-createdAt",
+    ...(typeof limit === "number" ? { limit } : { pagination: false }),
+    ...(locale ? { locale } : {}),
+  };
+};

--- a/src/lib/routes/publicRoutes.ts
+++ b/src/lib/routes/publicRoutes.ts
@@ -1,0 +1,76 @@
+/**
+ * Route grammar for the public catch-all route (`src/app/(frontend)/[...slugs]`).
+ *
+ * On a tenant subdomain:
+ *   /                       -> entity selector (tenant landing page)
+ *   /:slug                  -> entity index page when `:slug` matches a
+ *                              published political-entity slug for the tenant,
+ *                              otherwise a tenant (or global) page with that slug
+ *   /:entitySlug/:pageSlug  -> entity page; the first segment MUST match a
+ *                              published political-entity slug for the tenant
+ *   anything else           -> 404
+ *
+ * Without a tenant (apex domain):
+ *   /                       -> global "index" page
+ *   /:pageSlug              -> global page with that slug
+ *   anything else           -> 404
+ *
+ * Any path that does not match this grammar must call `notFound()` — there is
+ * no fallback content for unknown paths.
+ */
+
+type EntityLike = { slug: string };
+
+export type PublicRouteResolution<Entity extends EntityLike> =
+  | { type: "entity-selector" }
+  | { type: "entity-page"; entity: Entity; pageSlug: string }
+  | { type: "tenant-page"; pageSlug: string }
+  | { type: "not-found" };
+
+/**
+ * Resolves the tenant catch-all path segments against the tenant's published
+ * political entities. `entities` must already be scoped to the current tenant
+ * so that a slug collision with another tenant's entity can never resolve
+ * here; callers must use the returned entity object (not re-query by slug).
+ */
+export const resolvePublicRoute = <Entity extends EntityLike>(
+  slugs: string[],
+  entities: Entity[],
+): PublicRouteResolution<Entity> => {
+  if (slugs.length === 0) {
+    return { type: "entity-selector" };
+  }
+
+  if (slugs.length > 2) {
+    return { type: "not-found" };
+  }
+
+  const [first, second] = slugs;
+  const entity = entities.find((candidate) => candidate.slug === first);
+
+  if (entity) {
+    return { type: "entity-page", entity, pageSlug: second ?? "index" };
+  }
+
+  // Two segments require the first to be an entity slug; `/unknown/about`
+  // and similar paths are invalid rather than page lookups.
+  if (slugs.length === 2) {
+    return { type: "not-found" };
+  }
+
+  return { type: "tenant-page", pageSlug: first };
+};
+
+/**
+ * Resolves catch-all path segments when no tenant matched the subdomain.
+ * Only `/` and `/:pageSlug` are valid global paths.
+ */
+export const resolveGlobalRoute = (
+  slugs: string[],
+): { type: "global-page"; pageSlug: string } | { type: "not-found" } => {
+  if (slugs.length > 1) {
+    return { type: "not-found" };
+  }
+
+  return { type: "global-page", pageSlug: slugs[0] ?? "index" };
+};

--- a/tests/int/politicalEntitySlugs.int.spec.ts
+++ b/tests/int/politicalEntitySlugs.int.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TextField } from "payload";
+
+import { PoliticalEntities } from "@/collections/PoliticalEntities";
+import { ensureUniqueSlug } from "@/collections/PoliticalEntities/hooks/ensureUniqueSlug";
+
+const getSlugField = () =>
+  PoliticalEntities.fields.find(
+    (field): field is TextField =>
+      field.type === "text" && "name" in field && field.name === "slug",
+  );
+
+describe("political entity slug uniqueness", () => {
+  it("keeps the ensureUniqueSlug hook on the slug field", () => {
+    const slugField = getSlugField();
+
+    expect(slugField).toBeDefined();
+    expect(slugField?.hooks?.beforeValidate).toContain(ensureUniqueSlug);
+  });
+
+  it("indexes and requires the slug field", () => {
+    const slugField = getSlugField();
+
+    expect(slugField?.index).toBe(true);
+    expect(slugField?.required).toBe(true);
+  });
+
+  it("rejects a duplicate slug within the same tenant", async () => {
+    const find = vi.fn().mockImplementation(({ collection }) => {
+      if (collection === "political-entities") {
+        return { docs: [{ id: "existing", slug: "john-doe" }] };
+      }
+      return { docs: [{ id: "tenant-a", name: "Tenant A" }] };
+    });
+
+    await expect(
+      ensureUniqueSlug({
+        data: { tenant: "tenant-a" },
+        originalDoc: undefined,
+        req: { payload: { find } },
+        value: "john-doe",
+      } as never),
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "political-entities",
+        where: {
+          and: [
+            { slug: { equals: "john-doe" } },
+            { tenant: { equals: "tenant-a" } },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("allows a slug that is unique for the tenant", async () => {
+    const find = vi.fn().mockResolvedValue({ docs: [] });
+
+    await expect(
+      ensureUniqueSlug({
+        data: { tenant: "tenant-a" },
+        originalDoc: undefined,
+        req: { payload: { find } },
+        value: "unique-slug",
+      } as never),
+    ).resolves.toBe("unique-slug");
+  });
+
+  it("skips the check when the slug is unchanged", async () => {
+    const find = vi.fn();
+
+    await expect(
+      ensureUniqueSlug({
+        data: { tenant: "tenant-a" },
+        originalDoc: { slug: "john-doe" },
+        req: { payload: { find } },
+        value: "john-doe",
+      } as never),
+    ).resolves.toBe("john-doe");
+
+    expect(find).not.toHaveBeenCalled();
+  });
+});

--- a/tests/int/promiseListQuery.int.spec.ts
+++ b/tests/int/promiseListQuery.int.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPublishedPromisesQuery } from "@/lib/data/promiseQueries";
+
+describe("published promises list query", () => {
+  it("deliberately disables pagination for the main promise list", () => {
+    const query = buildPublishedPromisesQuery("entity-a");
+
+    // Without this, Payload silently caps results at its default page size
+    // (10) and the list omits records with no indication.
+    expect(query).toMatchObject({ pagination: false });
+    expect(query).not.toHaveProperty("limit");
+  });
+
+  it("scopes results to the resolved entity id and published status", () => {
+    const query = buildPublishedPromisesQuery("entity-a");
+
+    expect(query.where).toEqual({
+      and: [
+        { politicalEntity: { equals: "entity-a" } },
+        { publishStatus: { equals: "published" } },
+      ],
+    });
+  });
+
+  it("supports an explicit bounded limit for teaser lists", () => {
+    const query = buildPublishedPromisesQuery("entity-a", { limit: 3 });
+
+    expect(query).toMatchObject({ limit: 3 });
+    expect(query).not.toHaveProperty("pagination");
+  });
+
+  it("passes the locale through when provided", () => {
+    expect(buildPublishedPromisesQuery("entity-a", { locale: "fr" })).toMatchObject(
+      { locale: "fr" },
+    );
+  });
+});

--- a/tests/int/publicRoutes.int.spec.ts
+++ b/tests/int/publicRoutes.int.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveGlobalRoute,
+  resolvePublicRoute,
+} from "@/lib/routes/publicRoutes";
+
+const entities = [
+  { id: "entity-a", slug: "john-doe", tenant: "tenant-a" },
+  { id: "entity-b", slug: "jane-doe", tenant: "tenant-a" },
+];
+
+describe("resolvePublicRoute (tenant catch-all grammar)", () => {
+  it("resolves the root path to the entity selector", () => {
+    expect(resolvePublicRoute([], entities)).toEqual({
+      type: "entity-selector",
+    });
+  });
+
+  it("resolves a single entity slug to the entity index page", () => {
+    expect(resolvePublicRoute(["john-doe"], entities)).toEqual({
+      type: "entity-page",
+      entity: entities[0],
+      pageSlug: "index",
+    });
+  });
+
+  it("resolves an entity slug plus page slug to the entity page", () => {
+    expect(resolvePublicRoute(["jane-doe", "promises"], entities)).toEqual({
+      type: "entity-page",
+      entity: entities[1],
+      pageSlug: "promises",
+    });
+  });
+
+  it("treats a single non-entity segment as a tenant page lookup", () => {
+    expect(resolvePublicRoute(["about"], entities)).toEqual({
+      type: "tenant-page",
+      pageSlug: "about",
+    });
+  });
+
+  it("returns not-found for two segments when the first is not an entity", () => {
+    expect(resolvePublicRoute(["unknown", "about"], entities)).toEqual({
+      type: "not-found",
+    });
+  });
+
+  it("returns not-found for paths deeper than two segments", () => {
+    expect(
+      resolvePublicRoute(["john-doe", "promises", "extra"], entities),
+    ).toEqual({ type: "not-found" });
+  });
+
+  it("returns a tenant-page lookup (which may 404) when no entities exist", () => {
+    expect(resolvePublicRoute(["unknown"], [])).toEqual({
+      type: "tenant-page",
+      pageSlug: "unknown",
+    });
+  });
+
+  it("resolves the intended entity when another tenant shares the slug", () => {
+    // Entities are pre-scoped to the current tenant, so a same-slug entity
+    // belonging to another tenant can never be resolved here.
+    const tenantAEntities = [
+      { id: "entity-a", slug: "john-doe", tenant: "tenant-a" },
+    ];
+    const resolution = resolvePublicRoute(["john-doe"], tenantAEntities);
+
+    expect(resolution.type).toBe("entity-page");
+    if (resolution.type === "entity-page") {
+      expect(resolution.entity.id).toBe("entity-a");
+      expect(resolution.entity.tenant).toBe("tenant-a");
+    }
+  });
+
+  it("returns the full entity object so lookups use the resolved id", () => {
+    const resolution = resolvePublicRoute(["john-doe"], entities);
+
+    expect(resolution.type).toBe("entity-page");
+    if (resolution.type === "entity-page") {
+      expect(resolution.entity).toBe(entities[0]);
+    }
+  });
+});
+
+describe("resolveGlobalRoute (no tenant)", () => {
+  it("resolves the root path to the global index page", () => {
+    expect(resolveGlobalRoute([])).toEqual({
+      type: "global-page",
+      pageSlug: "index",
+    });
+  });
+
+  it("resolves a single segment to a global page lookup", () => {
+    expect(resolveGlobalRoute(["about"])).toEqual({
+      type: "global-page",
+      pageSlug: "about",
+    });
+  });
+
+  it("returns not-found for multi-segment paths", () => {
+    expect(resolveGlobalRoute(["unknown", "about"])).toEqual({
+      type: "not-found",
+    });
+  });
+});


### PR DESCRIPTION
Closes #574

## What changed

### Route grammar & 404s
- Added [src/lib/routes/publicRoutes.ts](https://github.com/CodeForAfrica/PromiseTracker/blob/claude/issue-574-948130/src/lib/routes/publicRoutes.ts) — a pure, documented resolver for the `[...slugs]` catch-all grammar (tenant: `/`, `/:entitySlug`, `/:entitySlug/:pageSlug`, `/:pageSlug`; global: `/` and `/:pageSlug` only).
- The catch-all page now calls `notFound()` for every non-matching path. `/unknown` (no matching entity or page), `/unknown/about`, and 3+ segment paths return real 404s instead of silently rendering the entity selector.

### Entity resolution
- Fixed `slugField` overwriting `slugOverrides.hooks`, which silently disabled the `ensureUniqueSlug` beforeValidate hook on political entities — per-tenant slug uniqueness is now actually enforced.
- Added a verification migration that fails loudly if pre-existing duplicate `(tenant, slug)` pairs exist.
- `BlockRenderer` now passes the route-resolved entity object to blocks; `promise-list` and `latest-promises` blocks use it directly instead of re-resolving by slug without tenant scoping (previously a cross-tenant slug collision could resolve the wrong entity). Their fallback slug lookup is now tenant-scoped.

### Promise lists
- The main promise list previously fetched with no `limit`, so Payload silently capped it at 10 records. It now deliberately requests all published promises (`pagination: false`) via a shared, tested query builder; the teaser list keeps its explicit `limit: 3`.

### Branded error handling
- Added `(frontend)/not-found.tsx` and `(frontend)/error.tsx` (Sentry-instrumented) so 404s/500s get branded pages while preserving HTTP semantics via `notFound()`.

## Migrations
- `migrations/20260720_000000_check_political_entity_slug_uniqueness.ts` — verification only; throws with a list of duplicates if any exist, no data changes.

## Tests
- `tests/int/publicRoutes.int.spec.ts` — route matrix: tenant, global, entity, duplicate-slug, and invalid paths.
- `tests/int/politicalEntitySlugs.int.spec.ts` — slug field keeps the uniqueness hook; hook rejects duplicates per tenant.
- `tests/int/promiseListQuery.int.spec.ts` — pagination behavior of the promise list query.
- Full int suite: 122/122 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)