### PR TITLE
Bound and monitor AI extraction workflows

### DIFF
--- a/migrations/20260720_000001_backfill_ai_extraction_row_unique_ids.ts
+++ b/migrations/20260720_000001_backfill_ai_extraction_row_unique_ids.ts
@@ -1,0 +1,54 @@
+import type { MigrateUpArgs } from "@payloadcms/db-mongodb";
+import { assignMissingExtractionRowUniqueIds } from "../src/lib/aiExtractionUniqueIds";
+
+/**
+ * Every AI extraction row now requires a system-generated uniqueId so each
+ * extraction can be matched to its downstream upload. This migration
+ * backfills a uniqueId onto any pre-existing extraction rows missing one.
+ */
+export async function up({ payload }: MigrateUpArgs): Promise<void> {
+  const batchSize = 100;
+  let page = 1;
+  let hasNextPage = true;
+  let updated = 0;
+
+  while (hasNextPage) {
+    const result = await payload.find({
+      collection: "ai-extractions",
+      limit: batchSize,
+      page,
+      depth: 0,
+      overrideAccess: true,
+    });
+
+    for (const doc of result.docs) {
+      const backfilled = assignMissingExtractionRowUniqueIds(doc.extractions);
+      if (!backfilled) {
+        continue;
+      }
+
+      await payload.update({
+        collection: "ai-extractions",
+        id: doc.id,
+        depth: 0,
+        overrideAccess: true,
+        data: {
+          extractions:
+            backfilled as unknown as (typeof doc)["extractions"],
+        },
+      });
+      updated += 1;
+    }
+
+    hasNextPage = result.hasNextPage;
+    page += 1;
+  }
+
+  payload.logger.info(
+    `backfill_ai_extraction_row_unique_ids:: backfilled uniqueIds on ${updated} extraction record(s)`,
+  );
+}
+
+export async function down(): Promise<void> {
+  // Backfill only; generated IDs are harmless to keep.
+}

--- a/src/collections/AIExtractions/index.ts
+++ b/src/collections/AIExtractions/index.ts
@@ -1,9 +1,13 @@
-import type { CollectionConfig } from "payload";
+import { randomUUID } from "node:crypto";
+import type { CollectionConfig, FieldHook } from "payload";
 import { authenticatedUsers } from "@/access/roles";
 import {
   deleteAIExtractionExportRowsAfterAIExtractionDelete,
   queueAIExtractionExportRowsSyncAfterAIExtractionChange,
 } from "./hooks";
+
+export const ensureExtractionRowUniqueId: FieldHook = ({ value }) =>
+  typeof value === "string" && value.trim() ? value : randomUUID();
 
 export const AIExtractions: CollectionConfig = {
   slug: "ai-extractions",
@@ -104,8 +108,14 @@ export const AIExtractions: CollectionConfig = {
             {
               name: "uniqueId",
               type: "text",
+              // Required so every extraction row can be matched to its
+              // downstream upload; system-generated, never user-supplied.
+              required: true,
               admin: {
                 hidden: true,
+              },
+              hooks: {
+                beforeValidate: [ensureExtractionRowUniqueId],
               },
               label: {
                 en: "Unique ID",

--- a/src/collections/Documents/index.ts
+++ b/src/collections/Documents/index.ts
@@ -157,6 +157,52 @@ export const Documents: CollectionConfig = {
       },
     },
     {
+      // Explicit operator-reviewable state for documents the AI extraction
+      // pipeline rejected (over size limits) or truncated (chunk/candidate
+      // ceilings), or that failed terminally. Cleared by operators after
+      // review; documents in this state are visible in admin filters.
+      name: "extractionReview",
+      type: "group",
+      label: {
+        en: "Extraction Review",
+        fr: "Révision de l'extraction",
+      },
+      admin: {
+        position: "sidebar",
+      },
+      fields: [
+        {
+          name: "status",
+          type: "select",
+          options: [
+            { value: "rejected", label: { en: "Rejected", fr: "Rejeté" } },
+            { value: "truncated", label: { en: "Truncated", fr: "Tronqué" } },
+            { value: "failed", label: { en: "Failed", fr: "Échoué" } },
+          ],
+          label: {
+            en: "Status",
+            fr: "Statut",
+          },
+        },
+        {
+          name: "reason",
+          type: "text",
+          label: {
+            en: "Reason",
+            fr: "Raison",
+          },
+        },
+        {
+          name: "flaggedAt",
+          type: "date",
+          label: {
+            en: "Flagged At",
+            fr: "Signalé le",
+          },
+        },
+      ],
+    },
+    {
       type: "tabs",
       admin: {
         readOnly: true,

--- a/src/collections/WorkflowLocks.ts
+++ b/src/collections/WorkflowLocks.ts
@@ -1,0 +1,47 @@
+import type { CollectionConfig } from "payload";
+
+/**
+ * System collection backing the atomic queued/running guard for scheduled
+ * workflows. One document per workflow slug; acquisition happens through an
+ * atomic findOneAndUpdate (see src/lib/workflowLocks.ts), never through the
+ * Payload API, so overlapping cron runs can never both hold the lock.
+ */
+export const WorkflowLocks: CollectionConfig = {
+  slug: "workflow-locks",
+  admin: {
+    hidden: true,
+  },
+  access: {
+    read: () => false,
+    create: () => false,
+    update: () => false,
+    delete: () => false,
+  },
+  fields: [
+    {
+      name: "workflow",
+      type: "text",
+      required: true,
+      unique: true,
+      index: true,
+    },
+    {
+      name: "runId",
+      type: "text",
+    },
+    {
+      name: "status",
+      type: "select",
+      options: ["idle", "running"],
+      defaultValue: "idle",
+    },
+    {
+      name: "lockedAt",
+      type: "date",
+    },
+    {
+      name: "expiresAt",
+      type: "date",
+    },
+  ],
+};

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -12,6 +12,7 @@ import { Partners } from "./Partners";
 import { PoliticalEntities } from "./PoliticalEntities";
 import { PromiseStatus } from "./PromiseStatus";
 import { GlobalPages } from "./Pages/GlobalPages";
+import { WorkflowLocks } from "./WorkflowLocks";
 
 export const collections: CollectionConfig[] = [
   Documents,
@@ -27,4 +28,5 @@ export const collections: CollectionConfig[] = [
   Partners,
   PoliticalEntities,
   PromiseStatus,
+  WorkflowLocks,
 ];

--- a/src/globals/Settings/tabs/AITab.ts
+++ b/src/globals/Settings/tabs/AITab.ts
@@ -601,6 +601,98 @@ export const AITab: Tab = {
           },
         },
         {
+          name: "limits",
+          type: "group",
+          label: {
+            en: "Extraction Limits",
+            fr: "Limites d'extraction",
+          },
+          admin: {
+            description:
+              "Operational ceilings for AI extraction. Leave blank to use safe defaults. Rejected or truncated documents are flagged for operator review.",
+          },
+          fields: [
+            {
+              type: "row",
+              fields: [
+                {
+                  name: "perCallTimeoutMs",
+                  type: "number",
+                  min: 1,
+                  label: { en: "Per-call timeout (ms)" },
+                  admin: { description: "Default: 120000" },
+                },
+                {
+                  name: "maxDocumentDurationMs",
+                  type: "number",
+                  min: 1,
+                  label: { en: "Max AI duration per document (ms)" },
+                  admin: { description: "Default: 1200000" },
+                },
+                {
+                  name: "maxRetriesPerCall",
+                  type: "number",
+                  min: 0,
+                  label: { en: "Max retries per call" },
+                  admin: { description: "Default: 4" },
+                },
+              ],
+            },
+            {
+              type: "row",
+              fields: [
+                {
+                  name: "maxDocumentChars",
+                  type: "number",
+                  min: 1,
+                  label: { en: "Max document characters" },
+                  admin: { description: "Default: 1500000" },
+                },
+                {
+                  name: "maxChunksPerDocument",
+                  type: "number",
+                  min: 1,
+                  label: { en: "Max chunks per document" },
+                  admin: { description: "Default: 120" },
+                },
+                {
+                  name: "maxTokensPerDocument",
+                  type: "number",
+                  min: 1,
+                  label: { en: "Max tokens per document" },
+                  admin: { description: "Default: 2000000" },
+                },
+              ],
+            },
+            {
+              type: "row",
+              fields: [
+                {
+                  name: "maxCostUsdPerDocument",
+                  type: "number",
+                  min: 0,
+                  label: { en: "Max cost per document (USD)" },
+                  admin: { description: "Default: 10" },
+                },
+                {
+                  name: "inputCostUsdPerMillionTokens",
+                  type: "number",
+                  min: 0,
+                  label: { en: "Input cost (USD / 1M tokens)" },
+                  admin: { description: "Default: 3" },
+                },
+                {
+                  name: "outputCostUsdPerMillionTokens",
+                  type: "number",
+                  min: 0,
+                  label: { en: "Output cost (USD / 1M tokens)" },
+                  admin: { description: "Default: 15" },
+                },
+              ],
+            },
+          ],
+        },
+        {
           name: "model",
           type: "select",
           label: {

--- a/src/lib/ai/documentBudget.ts
+++ b/src/lib/ai/documentBudget.ts
@@ -1,0 +1,100 @@
+import type { ExtractionLimits } from "./extractionLimits";
+
+export type BudgetExceededReason = "duration" | "tokens" | "cost";
+
+export class ExtractionBudgetExceededError extends Error {
+  readonly reason: BudgetExceededReason;
+
+  constructor(reason: BudgetExceededReason, message: string) {
+    super(message);
+    this.name = "ExtractionBudgetExceededError";
+    this.reason = reason;
+  }
+}
+
+export type AIUsage = {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  totalTokens?: number | null;
+};
+
+/**
+ * Tracks per-document AI spend (wall-clock time, tokens, estimated cost)
+ * against the configured ceilings. Call `assertWithinBudget()` before every
+ * AI call and `recordUsage()` after; once any ceiling is crossed the document
+ * fails fast instead of continuing to accrue provider cost.
+ */
+export const createDocumentBudget = (
+  limits: ExtractionLimits,
+  now: () => number = Date.now,
+) => {
+  const startedAt = now();
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let calls = 0;
+  let retries = 0;
+
+  const totalTokens = () => inputTokens + outputTokens;
+  const costUsd = () =>
+    (inputTokens / 1_000_000) * limits.inputCostUsdPerMillionTokens +
+    (outputTokens / 1_000_000) * limits.outputCostUsdPerMillionTokens;
+  const elapsedMs = () => now() - startedAt;
+
+  const assertWithinBudget = () => {
+    if (elapsedMs() > limits.maxDocumentDurationMs) {
+      throw new ExtractionBudgetExceededError(
+        "duration",
+        `Document exceeded its total AI duration budget (${limits.maxDocumentDurationMs}ms).`,
+      );
+    }
+    if (totalTokens() > limits.maxTokensPerDocument) {
+      throw new ExtractionBudgetExceededError(
+        "tokens",
+        `Document exceeded its token budget (${limits.maxTokensPerDocument} tokens).`,
+      );
+    }
+    if (costUsd() > limits.maxCostUsdPerDocument) {
+      throw new ExtractionBudgetExceededError(
+        "cost",
+        `Document exceeded its cost budget (USD ${limits.maxCostUsdPerDocument}).`,
+      );
+    }
+  };
+
+  const recordUsage = (usage?: AIUsage | null) => {
+    calls += 1;
+    if (!usage) {
+      return;
+    }
+    const input = usage.inputTokens ?? 0;
+    const output = usage.outputTokens ?? 0;
+    if (input || output) {
+      inputTokens += input;
+      outputTokens += output;
+    } else if (usage.totalTokens) {
+      // Providers that only report a total; attribute it to input pricing.
+      inputTokens += usage.totalTokens;
+    }
+  };
+
+  const recordRetries = (count: number) => {
+    retries += count;
+  };
+
+  return {
+    assertWithinBudget,
+    recordUsage,
+    recordRetries,
+    snapshot: () => ({
+      elapsedMs: elapsedMs(),
+      inputTokens,
+      outputTokens,
+      totalTokens: totalTokens(),
+      costUsd: Number(costUsd().toFixed(6)),
+      calls,
+      retries,
+    }),
+  };
+};
+
+export type DocumentBudget = ReturnType<typeof createDocumentBudget>;

--- a/src/lib/ai/extractionLimits.ts
+++ b/src/lib/ai/extractionLimits.ts
@@ -1,0 +1,73 @@
+/**
+ * Operational ceilings for AI extraction runs. Every AI call gets a per-call
+ * deadline, and each document has total duration, character, chunk, token,
+ * retry, and cost ceilings. Values can be overridden per-deployment from the
+ * Settings → Generative AI → Extraction Limits group; anything unset falls
+ * back to these defaults.
+ */
+export type ExtractionLimits = {
+  /** Hard deadline for a single AI provider call (ms). */
+  perCallTimeoutMs: number;
+  /** Total wall-clock budget for all AI work on one document (ms). */
+  maxDocumentDurationMs: number;
+  /** Maximum extracted-text size accepted for AI analysis (characters). */
+  maxDocumentChars: number;
+  /** Maximum number of chunks processed per document. */
+  maxChunksPerDocument: number;
+  /** Total token budget (input + output) per document. */
+  maxTokensPerDocument: number;
+  /** Maximum retry attempts per AI call (after the initial attempt). */
+  maxRetriesPerCall: number;
+  /** Total provider cost budget per document (USD). */
+  maxCostUsdPerDocument: number;
+  /** Estimated input-token price used for cost accounting (USD per 1M). */
+  inputCostUsdPerMillionTokens: number;
+  /** Estimated output-token price used for cost accounting (USD per 1M). */
+  outputCostUsdPerMillionTokens: number;
+  /** Base delay for exponential backoff between retries (ms). */
+  retryBaseDelayMs: number;
+  /** Ceiling for a single backoff delay (ms). */
+  retryMaxDelayMs: number;
+};
+
+export const DEFAULT_EXTRACTION_LIMITS: ExtractionLimits = {
+  perCallTimeoutMs: 120_000,
+  maxDocumentDurationMs: 20 * 60_000,
+  maxDocumentChars: 1_500_000,
+  maxChunksPerDocument: 120,
+  maxTokensPerDocument: 2_000_000,
+  maxRetriesPerCall: 4,
+  maxCostUsdPerDocument: 10,
+  inputCostUsdPerMillionTokens: 3,
+  outputCostUsdPerMillionTokens: 15,
+  retryBaseDelayMs: 1_000,
+  retryMaxDelayMs: 60_000,
+};
+
+type LimitsInput = Partial<Record<keyof ExtractionLimits, unknown>>;
+
+const positiveNumber = (value: unknown): number | undefined => {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : undefined;
+};
+
+export const resolveExtractionLimits = (
+  aiSettings?: { limits?: LimitsInput | null } | null,
+): ExtractionLimits => {
+  const overrides = aiSettings?.limits ?? {};
+
+  return (
+    Object.keys(DEFAULT_EXTRACTION_LIMITS) as (keyof ExtractionLimits)[]
+  ).reduce<ExtractionLimits>(
+    (limits, key) => {
+      const override = positiveNumber(overrides[key]);
+      if (override !== undefined) {
+        limits[key] = override;
+      }
+      return limits;
+    },
+    { ...DEFAULT_EXTRACTION_LIMITS },
+  );
+};

--- a/src/lib/ai/retry.ts
+++ b/src/lib/ai/retry.ts
@@ -1,0 +1,159 @@
+import { APICallError } from "ai";
+
+export class RetryExhaustedError extends Error {
+  readonly attempts: number;
+  readonly lastError: unknown;
+
+  constructor(attempts: number, lastError: unknown) {
+    const lastMessage =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    super(`AI call failed after ${attempts} attempt(s): ${lastMessage}`);
+    this.name = "RetryExhaustedError";
+    this.attempts = attempts;
+    this.lastError = lastError;
+  }
+}
+
+export type RetryOptions = {
+  /** Retry attempts after the initial call. */
+  maxRetries: number;
+  /** Hard deadline per attempt (ms); enforced via AbortSignal. */
+  perCallTimeoutMs: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  onRetry?: (info: {
+    attempt: number;
+    delayMs: number;
+    error: unknown;
+  }) => void;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable for tests. */
+  random?: () => number;
+};
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error.name === "AbortError" ||
+    error.name === "TimeoutError" ||
+    /abort|timed? ?out/i.test(error.message));
+
+export const isRetryableAIError = (error: unknown): boolean => {
+  if (isAbortError(error)) {
+    return true;
+  }
+  if (APICallError.isInstance(error)) {
+    if (typeof error.isRetryable === "boolean") {
+      return error.isRetryable;
+    }
+    const status = error.statusCode ?? 0;
+    return status === 429 || status >= 500;
+  }
+  return false;
+};
+
+/**
+ * Reads provider rate-limit guidance (Retry-After / retry-after-ms headers)
+ * from an APICallError. Returns a delay in ms, or undefined when absent.
+ */
+export const getRetryAfterMs = (error: unknown): number | undefined => {
+  if (!APICallError.isInstance(error)) {
+    return undefined;
+  }
+  const headers = error.responseHeaders ?? {};
+  const lookup = (name: string) =>
+    headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()];
+
+  const retryAfterMs = Number(lookup("retry-after-ms"));
+  if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+    return retryAfterMs;
+  }
+
+  const retryAfter = lookup("retry-after");
+  if (retryAfter === undefined) {
+    return undefined;
+  }
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return seconds * 1_000;
+  }
+  const dateMs = Date.parse(String(retryAfter));
+  if (!Number.isNaN(dateMs)) {
+    const delay = dateMs - Date.now();
+    return delay > 0 ? delay : undefined;
+  }
+  return undefined;
+};
+
+export const computeBackoffDelayMs = ({
+  attempt,
+  baseDelayMs,
+  maxDelayMs,
+  retryAfterMs,
+  random = Math.random,
+}: {
+  attempt: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retryAfterMs?: number;
+  random?: () => number;
+}): number => {
+  const exponential = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+  // Full jitter keeps concurrent retries from thundering-herding a provider.
+  const jittered = exponential / 2 + random() * (exponential / 2);
+  // Provider rate-limit guidance is a floor, never shortened by jitter.
+  const withGuidance = Math.max(jittered, retryAfterMs ?? 0);
+  return Math.min(Math.round(withGuidance), Math.max(maxDelayMs, retryAfterMs ?? 0));
+};
+
+/**
+ * Runs an AI call with a per-attempt deadline and bounded exponential
+ * backoff. The callback receives an AbortSignal it MUST pass to the provider
+ * call. Non-retryable errors are rethrown immediately; retryable errors are
+ * retried up to `maxRetries` times, then wrapped in RetryExhaustedError.
+ */
+export const callAIWithRetry = async <T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  {
+    maxRetries,
+    perCallTimeoutMs,
+    baseDelayMs = 1_000,
+    maxDelayMs = 60_000,
+    onRetry,
+    sleep = defaultSleep,
+    random = Math.random,
+  }: RetryOptions,
+): Promise<{ result: T; retries: number }> => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      const result = await fn(AbortSignal.timeout(perCallTimeoutMs));
+      return { result, retries: attempt };
+    } catch (error) {
+      lastError = error;
+
+      if (!isRetryableAIError(error) || attempt === maxRetries) {
+        break;
+      }
+
+      const delayMs = computeBackoffDelayMs({
+        attempt,
+        baseDelayMs,
+        maxDelayMs,
+        retryAfterMs: getRetryAfterMs(error),
+        random,
+      });
+      onRetry?.({ attempt: attempt + 1, delayMs, error });
+      await sleep(delayMs);
+    }
+  }
+
+  if (isRetryableAIError(lastError)) {
+    throw new RetryExhaustedError(maxRetries + 1, lastError);
+  }
+  throw lastError;
+};

--- a/src/lib/aiExtractionUniqueIds.ts
+++ b/src/lib/aiExtractionUniqueIds.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from "node:crypto";
+
+type ExtractionRowLike = {
+  uniqueId?: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Returns a copy of the extraction rows with a system-generated uniqueId
+ * assigned to every row missing one, or null when nothing needs backfilling.
+ * Used by the AIExtractions field hook's migration counterpart so existing
+ * records satisfy the required-uniqueId invariant.
+ */
+export const assignMissingExtractionRowUniqueIds = (
+  extractions: ExtractionRowLike[] | null | undefined,
+  generateId: () => string = randomUUID,
+): ExtractionRowLike[] | null => {
+  if (!Array.isArray(extractions) || extractions.length === 0) {
+    return null;
+  }
+
+  let changed = false;
+  const next = extractions.map((row) => {
+    if (typeof row?.uniqueId === "string" && row.uniqueId.trim()) {
+      return row;
+    }
+    changed = true;
+    return { ...row, uniqueId: generateId() };
+  });
+
+  return changed ? next : null;
+};

--- a/src/lib/workflowLocks.ts
+++ b/src/lib/workflowLocks.ts
@@ -1,0 +1,126 @@
+import type { Payload } from "payload";
+
+export const WORKFLOW_LOCKS_COLLECTION = "workflow-locks" as const;
+
+/**
+ * How long a lock stays valid without being released. A crashed run's lock
+ * expires after this TTL so the workflow is not blocked forever; matches the
+ * intent of the stuck-job cleanup (PAYLOAD_JOBS_STUCK_TIMEOUT_HOURS).
+ */
+export const DEFAULT_WORKFLOW_LOCK_TTL_MS = 2 * 60 * 60 * 1_000;
+
+type MongoLikeModel = {
+  findOneAndUpdate: (
+    filter: Record<string, unknown>,
+    update: Record<string, unknown>,
+    options: Record<string, unknown>,
+  ) => { lean?: () => Promise<unknown> } | Promise<unknown>;
+};
+
+const getModel = (payload: Payload): MongoLikeModel => {
+  const collections = (
+    payload.db as unknown as {
+      collections?: Record<string, MongoLikeModel>;
+    }
+  ).collections;
+  const model = collections?.[WORKFLOW_LOCKS_COLLECTION];
+  if (!model) {
+    throw new Error(
+      `workflowLocks:: collection "${WORKFLOW_LOCKS_COLLECTION}" is not registered on the database adapter`,
+    );
+  }
+  return model;
+};
+
+const run = async (
+  model: MongoLikeModel,
+  filter: Record<string, unknown>,
+  update: Record<string, unknown>,
+  options: Record<string, unknown>,
+): Promise<Record<string, unknown> | null> => {
+  const query = model.findOneAndUpdate(filter, update, options);
+  const result =
+    query && typeof (query as { lean?: unknown }).lean === "function"
+      ? await (query as { lean: () => Promise<unknown> }).lean()
+      : await query;
+  return (result as Record<string, unknown> | null) ?? null;
+};
+
+const isDuplicateKeyError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { code?: number }).code === 11000;
+
+/**
+ * Atomically acquires the run lock for a workflow. Returns true when this
+ * run now holds the lock; false when another run already holds a live lock.
+ * A lock is acquirable when no document exists, the previous run released it
+ * (status "idle"), or the previous lock expired (crashed run).
+ */
+export const acquireWorkflowLock = async (
+  payload: Payload,
+  {
+    workflow,
+    runId,
+    ttlMs = DEFAULT_WORKFLOW_LOCK_TTL_MS,
+    now = () => new Date(),
+  }: {
+    workflow: string;
+    runId: string;
+    ttlMs?: number;
+    now?: () => Date;
+  },
+): Promise<boolean> => {
+  const model = getModel(payload);
+  const nowDate = now();
+
+  try {
+    const doc = await run(
+      model,
+      {
+        workflow,
+        $or: [
+          { status: { $ne: "running" } },
+          { expiresAt: { $lt: nowDate } },
+          { expiresAt: null },
+        ],
+      },
+      {
+        $set: {
+          workflow,
+          runId,
+          status: "running",
+          lockedAt: nowDate,
+          expiresAt: new Date(nowDate.getTime() + ttlMs),
+        },
+      },
+      { upsert: true, new: true },
+    );
+
+    return doc?.runId === runId;
+  } catch (error) {
+    // Upsert raced another acquirer on the unique workflow index — the other
+    // run holds the lock.
+    if (isDuplicateKeyError(error)) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Releases the lock, but only if this run still owns it — a lock taken over
+ * after expiry must not be released by the stale run.
+ */
+export const releaseWorkflowLock = async (
+  payload: Payload,
+  { workflow, runId }: { workflow: string; runId: string },
+): Promise<void> => {
+  const model = getModel(payload);
+  await run(
+    model,
+    { workflow, runId, status: "running" },
+    { $set: { status: "idle" } },
+    { new: true },
+  );
+};

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -80,6 +80,7 @@ export interface Config {
     partners: Partner;
     'political-entities': PoliticalEntity;
     'promise-status': PromiseStatus;
+    'workflow-locks': WorkflowLock;
     exports: Export;
     imports: Import;
     'payload-kv': PayloadKv;
@@ -103,6 +104,7 @@ export interface Config {
     partners: PartnersSelect<false> | PartnersSelect<true>;
     'political-entities': PoliticalEntitiesSelect<false> | PoliticalEntitiesSelect<true>;
     'promise-status': PromiseStatusSelect<false> | PromiseStatusSelect<true>;
+    'workflow-locks': WorkflowLocksSelect<false> | WorkflowLocksSelect<true>;
     exports: ExportsSelect<false> | ExportsSelect<true>;
     imports: ImportsSelect<false> | ImportsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -196,6 +198,11 @@ export interface Document {
   type?: ('promise' | 'evidence') | null;
   airtableID?: string | null;
   fullyProcessed?: boolean | null;
+  extractionReview?: {
+    status?: ('rejected' | 'truncated' | 'failed') | null;
+    reason?: string | null;
+    flaggedAt?: string | null;
+  };
   extractedText?:
     | {
         text?: {
@@ -371,7 +378,7 @@ export interface AiExtraction {
         category: string;
         summary: string;
         source: string;
-        uniqueId?: string | null;
+        uniqueId: string;
         checkMediaId?: string | null;
         checkMediaURL?: string | null;
         Status?: (string | null) | PromiseStatus;
@@ -988,6 +995,20 @@ export interface SiteSetting {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "workflow-locks".
+ */
+export interface WorkflowLock {
+  id: string;
+  workflow: string;
+  runId?: string | null;
+  status?: ('idle' | 'running') | null;
+  lockedAt?: string | null;
+  expiresAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "exports".
  */
 export interface Export {
@@ -1293,6 +1314,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'promise-status';
         value: string | PromiseStatus;
+      } | null)
+    | ({
+        relationTo: 'workflow-locks';
+        value: string | WorkflowLock;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -1355,6 +1380,13 @@ export interface DocumentsSelect<T extends boolean = true> {
   type?: T;
   airtableID?: T;
   fullyProcessed?: T;
+  extractionReview?:
+    | T
+    | {
+        status?: T;
+        reason?: T;
+        flaggedAt?: T;
+      };
   extractedText?:
     | T
     | {
@@ -1901,6 +1933,19 @@ export interface PromiseStatusSelect<T extends boolean = true> {
         color?: T;
         textColor?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "workflow-locks_select".
+ */
+export interface WorkflowLocksSelect<T extends boolean = true> {
+  workflow?: T;
+  runId?: T;
+  status?: T;
+  lockedAt?: T;
+  expiresAt?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -2521,6 +2566,47 @@ export interface Setting {
      * Optional override in "provider:model" format. Must match the selected provider.
      */
     customModelId?: string | null;
+    /**
+     * Operational ceilings for AI extraction. Leave blank to use safe defaults. Rejected or truncated documents are flagged for operator review.
+     */
+    limits?: {
+      /**
+       * Default: 120000
+       */
+      perCallTimeoutMs?: number | null;
+      /**
+       * Default: 1200000
+       */
+      maxDocumentDurationMs?: number | null;
+      /**
+       * Default: 4
+       */
+      maxRetriesPerCall?: number | null;
+      /**
+       * Default: 1500000
+       */
+      maxDocumentChars?: number | null;
+      /**
+       * Default: 120
+       */
+      maxChunksPerDocument?: number | null;
+      /**
+       * Default: 2000000
+       */
+      maxTokensPerDocument?: number | null;
+      /**
+       * Default: 10
+       */
+      maxCostUsdPerDocument?: number | null;
+      /**
+       * Default: 3
+       */
+      inputCostUsdPerMillionTokens?: number | null;
+      /**
+       * Default: 15
+       */
+      outputCostUsdPerMillionTokens?: number | null;
+    };
     model?: ('gemini-2.5-pro' | 'gemini-2.5-flash-lite') | null;
     apiKey?: string | null;
   };
@@ -2859,6 +2945,19 @@ export interface SettingsSelect<T extends boolean = true> {
         modelProvider?: T;
         modelPreset?: T;
         customModelId?: T;
+        limits?:
+          | T
+          | {
+              perCallTimeoutMs?: T;
+              maxDocumentDurationMs?: T;
+              maxRetriesPerCall?: T;
+              maxDocumentChars?: T;
+              maxChunksPerDocument?: T;
+              maxTokensPerDocument?: T;
+              maxCostUsdPerDocument?: T;
+              inputCostUsdPerMillionTokens?: T;
+              outputCostUsdPerMillionTokens?: T;
+            };
         model?: T;
         apiKey?: T;
       };

--- a/src/tasks/extractPromises.ts
+++ b/src/tasks/extractPromises.ts
@@ -5,6 +5,16 @@ import { TaskConfig } from "payload";
 import { z } from "zod";
 import { updateDocumentStatus } from "@/lib/airtable";
 import {
+  createDocumentBudget,
+  ExtractionBudgetExceededError,
+  type DocumentBudget,
+} from "@/lib/ai/documentBudget";
+import {
+  resolveExtractionLimits,
+  type ExtractionLimits,
+} from "@/lib/ai/extractionLimits";
+import { callAIWithRetry, RetryExhaustedError } from "@/lib/ai/retry";
+import {
   resolveConfiguredLanguageModel,
   type AISettingsInput,
 } from "@/lib/ai/providerRegistry";
@@ -16,6 +26,67 @@ const MAX_CHUNK_CHARS = 14_000;
 const CHUNK_OVERLAP_CHARS = 450;
 const MAX_NORMALIZATION_CANDIDATES = 220;
 const MAX_TOOL_STEPS = 40;
+
+type ReviewStatus = "rejected" | "truncated" | "failed";
+
+/**
+ * Runs one bounded AI call: per-call deadline, bounded exponential backoff
+ * with provider rate-limit guidance, and document-level budget accounting.
+ * Emits an `ai.call.complete` metric log per call.
+ */
+const runBoundedAICall = async <
+  T extends { usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } },
+>({
+  call,
+  callName,
+  limits,
+  budget,
+  logger,
+  documentId,
+}: {
+  call: (signal: AbortSignal) => Promise<T>;
+  callName: string;
+  limits: ExtractionLimits;
+  budget: DocumentBudget;
+  logger: TaskLogger;
+  documentId: string;
+}): Promise<T> => {
+  budget.assertWithinBudget();
+
+  const startedAt = Date.now();
+  const { result, retries } = await callAIWithRetry(call, {
+    maxRetries: limits.maxRetriesPerCall,
+    perCallTimeoutMs: limits.perCallTimeoutMs,
+    baseDelayMs: limits.retryBaseDelayMs,
+    maxDelayMs: limits.retryMaxDelayMs,
+    onRetry: ({ attempt, delayMs, error }) => {
+      logger.warn({
+        message: "extractPromises:: Retrying AI call",
+        callName,
+        documentId,
+        attempt,
+        delayMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  });
+
+  budget.recordUsage(result.usage ?? null);
+  budget.recordRetries(retries);
+
+  logger.info({
+    message: "ai.call.complete",
+    callName,
+    documentId,
+    durationMs: Date.now() - startedAt,
+    retries,
+    inputTokens: result.usage?.inputTokens ?? null,
+    outputTokens: result.usage?.outputTokens ?? null,
+    budget: budget.snapshot(),
+  });
+
+  return result;
+};
 
 const passOnePromiseSchema = z.object({
   category: z.string().min(1).describe("Thematic category for the promise"),
@@ -236,6 +307,8 @@ const extractPromisesFromChunks = async ({
   documentId,
   documentTitle,
   documentAirtableID,
+  limits,
+  budget,
 }: {
   model: ReturnType<typeof resolveConfiguredLanguageModel>["model"];
   chunks: string[];
@@ -243,6 +316,8 @@ const extractPromisesFromChunks = async ({
   documentId: string;
   documentTitle: string;
   documentAirtableID: string | null | undefined;
+  limits: ExtractionLimits;
+  budget: DocumentBudget;
 }) => {
   const candidates: PromiseCandidate[] = [];
   let recoverableChunkFailures = 0;
@@ -255,12 +330,23 @@ const extractPromisesFromChunks = async ({
 
   for (const [index, chunk] of chunks.entries()) {
     try {
-      const { output: chunkPromises } = await generateText({
-        model,
-        system: buildPassOneSystemPrompt(),
-        prompt: buildPassOnePrompt(chunk, index, chunks.length),
-        output,
-        maxRetries: 4,
+      const { output: chunkPromises } = await runBoundedAICall({
+        callName: "passOneChunkExtraction",
+        limits,
+        budget,
+        logger,
+        documentId,
+        call: (signal) =>
+          generateText({
+            model,
+            system: buildPassOneSystemPrompt(),
+            prompt: buildPassOnePrompt(chunk, index, chunks.length),
+            output,
+            // Retries/backoff are handled by callAIWithRetry so backoff and
+            // rate-limit guidance stay bounded and observable.
+            maxRetries: 0,
+            abortSignal: signal,
+          }),
       });
 
       candidates.push(...chunkPromises);
@@ -285,9 +371,16 @@ const extractPromisesFromChunks = async ({
         error: error instanceof Error ? error.message : String(error),
       });
 
+      // Budget ceilings are terminal for the document — stop immediately
+      // instead of burning further provider spend on remaining chunks.
+      if (error instanceof ExtractionBudgetExceededError) {
+        throw error;
+      }
+
       if (
         APICallError.isInstance(error) ||
-        NoObjectGeneratedError.isInstance(error)
+        NoObjectGeneratedError.isInstance(error) ||
+        error instanceof RetryExhaustedError
       ) {
         recoverableChunkFailures += 1;
         continue;
@@ -314,10 +407,18 @@ const normalizeCandidatesWithTools = async ({
   model,
   documentTitle,
   candidates,
+  limits,
+  budget,
+  logger,
+  documentId,
 }: {
   model: ReturnType<typeof resolveConfiguredLanguageModel>["model"];
   documentTitle: string;
   candidates: PromiseCandidate[];
+  limits: ExtractionLimits;
+  budget: DocumentBudget;
+  logger: TaskLogger;
+  documentId: string;
 }) => {
   const normalizedPromises: PromiseCandidate[] = [];
   let normalizedTitle = documentTitle;
@@ -352,17 +453,29 @@ const normalizeCandidatesWithTools = async ({
     },
   });
 
-  const normalizationRun = await generateText({
-    model,
-    system: buildNormalizationSystemPrompt(),
-    prompt: buildNormalizationPrompt({ documentTitle, candidates }),
-    tools: {
-      recordPromise,
-      finalizeExtraction,
-    },
-    toolChoice: "required",
-    stopWhen: [hasToolCall("finalizeExtraction"), stepCountIs(MAX_TOOL_STEPS)],
-    maxRetries: 3,
+  const normalizationRun = await runBoundedAICall({
+    callName: "normalizeCandidates",
+    limits,
+    budget,
+    logger,
+    documentId,
+    call: (signal) =>
+      generateText({
+        model,
+        system: buildNormalizationSystemPrompt(),
+        prompt: buildNormalizationPrompt({ documentTitle, candidates }),
+        tools: {
+          recordPromise,
+          finalizeExtraction,
+        },
+        toolChoice: "required",
+        stopWhen: [
+          hasToolCall("finalizeExtraction"),
+          stepCountIs(MAX_TOOL_STEPS),
+        ],
+        maxRetries: 0,
+        abortSignal: signal,
+      }),
   });
 
   const finalized = normalizationRun.steps.some((step) =>
@@ -410,10 +523,15 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
           requireExtractionCapabilities: true,
         });
 
+      const limits = resolveExtractionLimits(
+        settings.ai as Parameters<typeof resolveExtractionLimits>[0],
+      );
+
       logger.info({
         message: "extractPromises:: Resolved AI model",
         modelId,
         providerId,
+        limits,
       });
 
       const setDocumentStatus = async (
@@ -448,6 +566,54 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
         reason: string,
       ) => {
         await setDocumentStatus(airtableID, `Failed: ${reason}`);
+      };
+
+      // Puts a document into the explicit operator-reviewable state (visible
+      // in the admin sidebar and mirrored to Airtable) when the pipeline
+      // rejects, truncates, or terminally fails it.
+      const flagDocumentForReview = async (
+        document: { id: string; airtableID?: string | null; title?: string },
+        status: ReviewStatus,
+        reason: string,
+      ) => {
+        try {
+          await payload.update({
+            collection: "documents",
+            id: document.id,
+            data: {
+              extractionReview: {
+                status,
+                reason,
+                flaggedAt: new Date().toISOString(),
+              },
+            },
+          });
+        } catch (updateError) {
+          logger.error({
+            message:
+              "extractPromises:: Failed to persist extraction review state",
+            documentId: document.id,
+            reviewStatus: status,
+            reason,
+            error:
+              updateError instanceof Error
+                ? updateError.message
+                : String(updateError),
+          });
+        }
+
+        await setDocumentStatus(
+          document.airtableID,
+          `Needs Review: ${reason}`,
+        );
+
+        logger.warn({
+          message: "ai.document.review_flagged",
+          documentId: document.id,
+          documentTitle: document.title,
+          reviewStatus: status,
+          reason,
+        });
       };
 
       const taskInput = input as TaskInput | undefined;
@@ -589,7 +755,31 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
             continue;
           }
 
-          const chunks = splitTextIntoChunks(plainText);
+          if (plainText.length > limits.maxDocumentChars) {
+            await flagDocumentForReview(
+              document,
+              "rejected",
+              `Extracted text (${plainText.length} chars) exceeds the ${limits.maxDocumentChars}-character limit`,
+            );
+            continue;
+          }
+
+          const budget = createDocumentBudget(limits);
+
+          let chunks = splitTextIntoChunks(plainText);
+          const chunksWereTruncated =
+            chunks.length > limits.maxChunksPerDocument;
+          if (chunksWereTruncated) {
+            chunks = chunks.slice(0, limits.maxChunksPerDocument);
+            logger.warn({
+              message:
+                "extractPromises:: Chunk list truncated to the per-document ceiling",
+              documentId: document.id,
+              documentTitle: document.title,
+              chunkLimit: limits.maxChunksPerDocument,
+            });
+          }
+
           const extractedCandidates = await extractPromisesFromChunks({
             model,
             chunks,
@@ -597,6 +787,8 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
             documentId: document.id,
             documentTitle: document.title,
             documentAirtableID: document.airtableID,
+            limits,
+            budget,
           });
 
           const mergedCandidates = mergeByAtomicPromise(
@@ -626,6 +818,10 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
             model,
             documentTitle: document.title,
             candidates: limitedCandidates,
+            limits,
+            budget,
+            logger,
+            documentId: document.id,
           });
 
           const finalPromises = mergeByAtomicPromise(
@@ -644,6 +840,16 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
             finalPromises: finalPromises.length,
             candidateListWasTruncated,
           });
+
+          if (chunksWereTruncated || candidateListWasTruncated) {
+            await flagDocumentForReview(
+              document,
+              "truncated",
+              chunksWereTruncated
+                ? `Document was truncated to ${limits.maxChunksPerDocument} chunks before AI analysis`
+                : `Candidate list was truncated to ${MAX_NORMALIZATION_CANDIDATES} before normalization`,
+            );
+          }
 
           const finalizeForceReextract = async () => {
             if (!shouldForceReextract || existingExtractions.length === 0) {
@@ -731,6 +937,16 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
               id: document.id,
               data: {
                 fullyProcessed: true,
+                // A clean run clears any stale operator-review flag.
+                ...(chunksWereTruncated || candidateListWasTruncated
+                  ? {}
+                  : {
+                      extractionReview: {
+                        status: null,
+                        reason: null,
+                        flaggedAt: null,
+                      },
+                    }),
               },
             });
 
@@ -748,6 +964,16 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
               id: document.id,
               data: {
                 fullyProcessed: true,
+                // A clean run clears any stale operator-review flag.
+                ...(chunksWereTruncated || candidateListWasTruncated
+                  ? {}
+                  : {
+                      extractionReview: {
+                        status: null,
+                        reason: null,
+                        flaggedAt: null,
+                      },
+                    }),
               },
             });
 
@@ -763,6 +989,15 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
             id: document.id,
             title: normalized.title || document.title,
             promises: finalPromises,
+          });
+
+          logger.info({
+            message: "ai.document.complete",
+            documentId: document.id,
+            documentTitle: document.title,
+            chunks: chunks.length,
+            finalPromises: finalPromises.length,
+            ...budget.snapshot(),
           });
         } catch (documentError) {
           if (
@@ -804,7 +1039,30 @@ export const ExtractPromises: TaskConfig<"extractPromises"> = {
             documentError instanceof Error
               ? documentError.message
               : String(documentError);
-          await setDocumentFailedStatus(document.airtableID, errorMessage);
+
+          // Budget/retry exhaustion is terminal for the document — surface
+          // it in the operator-reviewable state rather than only in Airtable.
+          if (
+            documentError instanceof ExtractionBudgetExceededError ||
+            documentError instanceof RetryExhaustedError
+          ) {
+            await flagDocumentForReview(document, "failed", errorMessage);
+          } else {
+            await setDocumentFailedStatus(document.airtableID, errorMessage);
+          }
+
+          logger.error({
+            message: "ai.document.terminal_failure",
+            documentId: document.id,
+            documentTitle: document.title,
+            reason:
+              documentError instanceof ExtractionBudgetExceededError
+                ? `budget:${documentError.reason}`
+                : documentError instanceof RetryExhaustedError
+                  ? "retry_exhausted"
+                  : "error",
+            error: errorMessage,
+          });
           logger.warn({
             message: `extractPromises:: Unexpected error processing document "${document.title ?? document.id}" — skipping`,
             documentId: document.id,

--- a/src/workflows/airtableWorkflow.ts
+++ b/src/workflows/airtableWorkflow.ts
@@ -1,9 +1,13 @@
 import { WorkflowConfig } from "payload";
 import { randomUUID } from "node:crypto";
+import * as Sentry from "@sentry/nextjs";
+import { acquireWorkflowLock, releaseWorkflowLock } from "@/lib/workflowLocks";
 import { defineWorkflow, runTask } from "./utils";
 
+const WORKFLOW_SLUG = "airtableWorkflow";
+
 export const airtableWorkflow = defineWorkflow({
-  slug: "airtableWorkflow",
+  slug: WORKFLOW_SLUG,
   label: "Airtable Workflow",
   schedule: [
     {
@@ -11,34 +15,78 @@ export const airtableWorkflow = defineWorkflow({
       queue: process.env.PAYLOAD_JOBS_QUEUE || "everyMinute",
     },
   ],
-  handler: async ({ tasks }) => {
-    await runTask(
-      () => tasks.createTenantFromAirtable(randomUUID(), { input: {} }),
-      "createTenantFromAirtable",
-    );
-    await runTask(
-      () => tasks.createPoliticalEntity(randomUUID(), { input: {} }),
-      "createPoliticalEntity",
-    );
-    await runTask(
-      () => tasks.fetchAirtableDocuments(randomUUID(), { input: {} }),
-      "fetchAirtableDocuments",
-    );
-    await runTask(
-      () => tasks.downloadDocuments(randomUUID(), { input: {} }),
-      "downloadDocuments",
-    );
-    await runTask(
-      () => tasks.extractDocuments(randomUUID(), { input: {} }),
-      "extractDocuments",
-    );
-    await runTask(
-      () => tasks.extractPromises(randomUUID(), { input: {} }),
-      "extractPromises",
-    );
-    await runTask(
-      () => tasks.uploadToMeedan(randomUUID(), { input: {} }),
-      "uploadToMeedan",
-    );
+  handler: async ({ tasks, job, req }) => {
+    const { payload } = req;
+    const runId = String(job?.id ?? randomUUID());
+
+    // Atomic queued/running guard: the every-minute cron must never stack a
+    // second run over the same work while a previous run is still going.
+    const acquired = await acquireWorkflowLock(payload, {
+      workflow: WORKFLOW_SLUG,
+      runId,
+    });
+
+    if (!acquired) {
+      payload.logger.warn({
+        message:
+          "airtableWorkflow:: Skipping run — previous run still holds the workflow lock",
+        workflow: WORKFLOW_SLUG,
+        runId,
+      });
+      // Overlap/pileup signal for alerting: repeated occurrences mean runs
+      // take longer than the schedule interval.
+      Sentry.logger.warn("workflow.overlap_skipped", {
+        log_source: "payload.workflow",
+        workflow: WORKFLOW_SLUG,
+        workflowRunId: runId,
+      });
+      return;
+    }
+
+    try {
+      await runWorkflowTasks(tasks);
+    } finally {
+      await releaseWorkflowLock(payload, {
+        workflow: WORKFLOW_SLUG,
+        runId,
+      });
+    }
   },
 } satisfies WorkflowConfig);
+
+type WorkflowHandlerFn = Extract<
+  NonNullable<WorkflowConfig["handler"]>,
+  (...args: never[]) => unknown
+>;
+type WorkflowTasks = Parameters<WorkflowHandlerFn>[0]["tasks"];
+
+async function runWorkflowTasks(tasks: WorkflowTasks) {
+  await runTask(
+    () => tasks.createTenantFromAirtable(randomUUID(), { input: {} }),
+    "createTenantFromAirtable",
+  );
+  await runTask(
+    () => tasks.createPoliticalEntity(randomUUID(), { input: {} }),
+    "createPoliticalEntity",
+  );
+  await runTask(
+    () => tasks.fetchAirtableDocuments(randomUUID(), { input: {} }),
+    "fetchAirtableDocuments",
+  );
+  await runTask(
+    () => tasks.downloadDocuments(randomUUID(), { input: {} }),
+    "downloadDocuments",
+  );
+  await runTask(
+    () => tasks.extractDocuments(randomUUID(), { input: {} }),
+    "extractDocuments",
+  );
+  await runTask(
+    () => tasks.extractPromises(randomUUID(), { input: {} }),
+    "extractPromises",
+  );
+  await runTask(
+    () => tasks.uploadToMeedan(randomUUID(), { input: {} }),
+    "uploadToMeedan",
+  );
+}

--- a/tests/int/aiExtractionBounds.int.spec.ts
+++ b/tests/int/aiExtractionBounds.int.spec.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from "vitest";
+import { APICallError } from "ai";
+
+import {
+  createDocumentBudget,
+  ExtractionBudgetExceededError,
+} from "@/lib/ai/documentBudget";
+import {
+  DEFAULT_EXTRACTION_LIMITS,
+  resolveExtractionLimits,
+} from "@/lib/ai/extractionLimits";
+import {
+  callAIWithRetry,
+  computeBackoffDelayMs,
+  getRetryAfterMs,
+  RetryExhaustedError,
+} from "@/lib/ai/retry";
+
+const apiError = (options: {
+  statusCode?: number;
+  isRetryable?: boolean;
+  responseHeaders?: Record<string, string>;
+}) =>
+  new APICallError({
+    message: "provider error",
+    url: "https://provider.example/v1",
+    requestBodyValues: {},
+    statusCode: options.statusCode,
+    isRetryable: options.isRetryable,
+    responseHeaders: options.responseHeaders,
+  });
+
+describe("extraction limits", () => {
+  it("falls back to defaults when settings provide nothing", () => {
+    expect(resolveExtractionLimits(undefined)).toEqual(
+      DEFAULT_EXTRACTION_LIMITS,
+    );
+    expect(resolveExtractionLimits({ limits: null })).toEqual(
+      DEFAULT_EXTRACTION_LIMITS,
+    );
+  });
+
+  it("applies positive overrides and ignores invalid ones", () => {
+    const limits = resolveExtractionLimits({
+      limits: {
+        perCallTimeoutMs: 5_000,
+        maxDocumentChars: -10,
+        maxTokensPerDocument: "250000",
+        maxCostUsdPerDocument: Number.NaN,
+      },
+    });
+
+    expect(limits.perCallTimeoutMs).toBe(5_000);
+    expect(limits.maxTokensPerDocument).toBe(250_000);
+    expect(limits.maxDocumentChars).toBe(
+      DEFAULT_EXTRACTION_LIMITS.maxDocumentChars,
+    );
+    expect(limits.maxCostUsdPerDocument).toBe(
+      DEFAULT_EXTRACTION_LIMITS.maxCostUsdPerDocument,
+    );
+  });
+});
+
+describe("document budget ceilings", () => {
+  const limits = {
+    ...DEFAULT_EXTRACTION_LIMITS,
+    maxDocumentDurationMs: 1_000,
+    maxTokensPerDocument: 100,
+    maxCostUsdPerDocument: 0.001,
+    inputCostUsdPerMillionTokens: 100,
+    outputCostUsdPerMillionTokens: 100,
+  };
+
+  it("throws once the total duration ceiling is crossed", () => {
+    let nowMs = 0;
+    const budget = createDocumentBudget(limits, () => nowMs);
+
+    expect(() => budget.assertWithinBudget()).not.toThrow();
+
+    nowMs = 1_001;
+    expect(() => budget.assertWithinBudget()).toThrowError(
+      ExtractionBudgetExceededError,
+    );
+    try {
+      budget.assertWithinBudget();
+    } catch (error) {
+      expect((error as ExtractionBudgetExceededError).reason).toBe("duration");
+    }
+  });
+
+  it("throws once the token ceiling is crossed", () => {
+    const budget = createDocumentBudget(
+      { ...limits, maxCostUsdPerDocument: 1_000 },
+      () => 0,
+    );
+    budget.recordUsage({ inputTokens: 80, outputTokens: 30 });
+
+    expect(() => budget.assertWithinBudget()).toThrowError(/token budget/);
+  });
+
+  it("throws once the estimated cost ceiling is crossed", () => {
+    const budget = createDocumentBudget(
+      { ...limits, maxTokensPerDocument: 1_000_000 },
+      () => 0,
+    );
+    // 100 tokens at 100 USD/M = 0.01 USD > 0.001 ceiling.
+    budget.recordUsage({ inputTokens: 100 });
+
+    expect(() => budget.assertWithinBudget()).toThrowError(/cost budget/);
+  });
+
+  it("tracks calls, retries, and cost in the snapshot", () => {
+    const budget = createDocumentBudget(DEFAULT_EXTRACTION_LIMITS, () => 0);
+    budget.recordUsage({ inputTokens: 1_000, outputTokens: 500 });
+    budget.recordRetries(2);
+
+    expect(budget.snapshot()).toMatchObject({
+      calls: 1,
+      retries: 2,
+      inputTokens: 1_000,
+      outputTokens: 500,
+      totalTokens: 1_500,
+    });
+  });
+});
+
+describe("bounded AI retries", () => {
+  it("enforces a per-call deadline via AbortSignal (provider timeout)", async () => {
+    vi.useFakeTimers();
+    try {
+      const call = (signal: AbortSignal) =>
+        new Promise<never>((_, reject) => {
+          signal.addEventListener("abort", () =>
+            reject(
+              Object.assign(new Error("The operation timed out"), {
+                name: "TimeoutError",
+              }),
+            ),
+          );
+        });
+
+      const promise = callAIWithRetry(call, {
+        maxRetries: 0,
+        perCallTimeoutMs: 50,
+      });
+      const assertion = expect(promise).rejects.toThrow(/timed out/i);
+      await vi.advanceTimersByTimeAsync(100);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries retryable provider errors and then succeeds", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    let attempts = 0;
+    const call = async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw apiError({ statusCode: 429, isRetryable: true });
+      }
+      return "ok";
+    };
+
+    const { result, retries } = await callAIWithRetry(call, {
+      maxRetries: 4,
+      perCallTimeoutMs: 1_000,
+      sleep,
+      random: () => 0.5,
+    });
+
+    expect(result).toBe("ok");
+    expect(retries).toBe(2);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses bounded exponential backoff between retries", () => {
+    const first = computeBackoffDelayMs({
+      attempt: 0,
+      baseDelayMs: 1_000,
+      maxDelayMs: 60_000,
+      random: () => 1,
+    });
+    const second = computeBackoffDelayMs({
+      attempt: 1,
+      baseDelayMs: 1_000,
+      maxDelayMs: 60_000,
+      random: () => 1,
+    });
+    const capped = computeBackoffDelayMs({
+      attempt: 20,
+      baseDelayMs: 1_000,
+      maxDelayMs: 60_000,
+      random: () => 1,
+    });
+
+    expect(first).toBe(1_000);
+    expect(second).toBe(2_000);
+    expect(capped).toBe(60_000);
+  });
+
+  it("respects provider Retry-After guidance as a floor", () => {
+    const error = apiError({
+      statusCode: 429,
+      isRetryable: true,
+      responseHeaders: { "retry-after": "30" },
+    });
+
+    expect(getRetryAfterMs(error)).toBe(30_000);
+    expect(
+      computeBackoffDelayMs({
+        attempt: 0,
+        baseDelayMs: 1_000,
+        maxDelayMs: 60_000,
+        retryAfterMs: 30_000,
+        random: () => 0,
+      }),
+    ).toBeGreaterThanOrEqual(30_000);
+  });
+
+  it("throws RetryExhaustedError after the retry budget is spent", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const call = async () => {
+      throw apiError({ statusCode: 503, isRetryable: true });
+    };
+
+    await expect(
+      callAIWithRetry(call, {
+        maxRetries: 2,
+        perCallTimeoutMs: 1_000,
+        sleep,
+      }),
+    ).rejects.toThrowError(RetryExhaustedError);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const call = async () => {
+      throw apiError({ statusCode: 400, isRetryable: false });
+    };
+
+    await expect(
+      callAIWithRetry(call, {
+        maxRetries: 5,
+        perCallTimeoutMs: 1_000,
+        sleep,
+      }),
+    ).rejects.toThrowError(/provider error/);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe("oversized documents", () => {
+  it("flags documents above the character ceiling for rejection", () => {
+    const limits = resolveExtractionLimits({
+      limits: { maxDocumentChars: 100 },
+    });
+    const oversized = "a".repeat(101);
+
+    expect(oversized.length > limits.maxDocumentChars).toBe(true);
+  });
+});

--- a/tests/int/aiExtractionUniqueIds.int.spec.ts
+++ b/tests/int/aiExtractionUniqueIds.int.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { ArrayField, Field, RowField, TextField } from "payload";
+
+import {
+  AIExtractions,
+  ensureExtractionRowUniqueId,
+} from "@/collections/AIExtractions";
+import { assignMissingExtractionRowUniqueIds } from "@/lib/aiExtractionUniqueIds";
+
+const getUniqueIdField = (): TextField | undefined => {
+  const extractions = AIExtractions.fields.find(
+    (field): field is ArrayField =>
+      field.type === "array" && field.name === "extractions",
+  );
+  const row = extractions?.fields.find(
+    (field): field is RowField => field.type === "row",
+  );
+  return row?.fields.find(
+    (field: Field): field is TextField =>
+      field.type === "text" && "name" in field && field.name === "uniqueId",
+  );
+};
+
+describe("AI extraction row unique IDs", () => {
+  it("requires a system-generated uniqueId on every extraction row", () => {
+    const uniqueId = getUniqueIdField();
+
+    expect(uniqueId).toBeDefined();
+    expect(uniqueId?.required).toBe(true);
+    expect(uniqueId?.hooks?.beforeValidate).toContain(
+      ensureExtractionRowUniqueId,
+    );
+  });
+
+  it("generates a uniqueId when the value is missing or blank", () => {
+    const generatedForUndefined = ensureExtractionRowUniqueId({
+      value: undefined,
+    } as never);
+    const generatedForBlank = ensureExtractionRowUniqueId({
+      value: "   ",
+    } as never);
+
+    expect(generatedForUndefined).toMatch(/[0-9a-f-]{36}/);
+    expect(generatedForBlank).toMatch(/[0-9a-f-]{36}/);
+    expect(generatedForUndefined).not.toBe(generatedForBlank);
+  });
+
+  it("keeps an existing uniqueId untouched", () => {
+    expect(
+      ensureExtractionRowUniqueId({ value: "existing-id" } as never),
+    ).toBe("existing-id");
+  });
+
+  describe("backfill helper (migration)", () => {
+    it("assigns IDs only to rows missing one", () => {
+      let counter = 0;
+      const generateId = () => `generated-${(counter += 1)}`;
+
+      const result = assignMissingExtractionRowUniqueIds(
+        [
+          { uniqueId: "keep-me", summary: "a" },
+          { uniqueId: "", summary: "b" },
+          { summary: "c" },
+        ],
+        generateId,
+      );
+
+      expect(result).toEqual([
+        { uniqueId: "keep-me", summary: "a" },
+        { uniqueId: "generated-1", summary: "b" },
+        { uniqueId: "generated-2", summary: "c" },
+      ]);
+    });
+
+    it("returns null when nothing needs backfilling", () => {
+      expect(
+        assignMissingExtractionRowUniqueIds([{ uniqueId: "ok" }]),
+      ).toBeNull();
+      expect(assignMissingExtractionRowUniqueIds([])).toBeNull();
+      expect(assignMissingExtractionRowUniqueIds(null)).toBeNull();
+    });
+  });
+});

--- a/tests/int/extractPromisesGuards.int.spec.ts
+++ b/tests/int/extractPromisesGuards.int.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  startSpan: vi.fn(async (_options, callback) => callback()),
+}));
+
+const generateText = vi.fn();
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  generateText: (...args: unknown[]) => generateText(...args),
+}));
+
+vi.mock("@/lib/ai/providerRegistry", () => ({
+  resolveConfiguredLanguageModel: vi.fn(() => ({
+    model: { id: "mock-model" },
+    modelId: "mock-model",
+    providerId: "mock-provider",
+  })),
+}));
+
+vi.mock("@/lib/airtable", () => ({
+  updateDocumentStatus: vi.fn(),
+}));
+
+vi.mock("@payloadcms/richtext-lexical/plaintext", () => ({
+  convertLexicalToPlaintext: vi.fn(
+    ({ data }: { data: { text: string } }) => data.text,
+  ),
+}));
+
+import { ExtractPromises } from "@/tasks/extractPromises";
+
+const buildLogger = () => {
+  const logger = {
+    child: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+};
+
+const buildPayload = ({
+  documentText,
+  limits,
+}: {
+  documentText: string;
+  limits: Record<string, number>;
+}) => {
+  const logger = buildLogger();
+  const document = {
+    id: "doc-1",
+    title: "Manifesto",
+    airtableID: null,
+    fullyProcessed: false,
+    extractedText: [{ text: { text: documentText } }],
+  };
+
+  const payload = {
+    logger,
+    findGlobal: vi.fn().mockResolvedValue({
+      airtable: { airtableAPIKey: null },
+      ai: { limits },
+    }),
+    find: vi.fn(async ({ collection }: { collection: string }) => {
+      if (collection === "documents") {
+        return { docs: [document], hasNextPage: false };
+      }
+      return { docs: [], hasNextPage: false };
+    }),
+    update: vi.fn().mockResolvedValue({}),
+    create: vi.fn().mockResolvedValue({ id: "extraction-1" }),
+    delete: vi.fn(),
+  };
+
+  return { payload, document };
+};
+
+const runHandler = async (payload: unknown) => {
+  if (typeof ExtractPromises.handler !== "function") {
+    throw new Error("ExtractPromises handler is not available");
+  }
+  return ExtractPromises.handler({
+    input: {},
+    req: { payload } as never,
+  } as never);
+};
+
+describe("extractPromises document guards", () => {
+  it("rejects oversized documents into the operator-review state without any AI call", async () => {
+    generateText.mockReset();
+    const { payload } = buildPayload({
+      documentText: "a".repeat(500),
+      limits: { maxDocumentChars: 100 },
+    });
+
+    await runHandler(payload);
+
+    expect(generateText).not.toHaveBeenCalled();
+    expect(payload.create).not.toHaveBeenCalled();
+
+    const reviewUpdate = payload.update.mock.calls.find(
+      ([args]) => args.data?.extractionReview,
+    );
+    expect(reviewUpdate).toBeDefined();
+    expect(reviewUpdate?.[0].data.extractionReview).toMatchObject({
+      status: "rejected",
+      reason: expect.stringContaining("exceeds"),
+    });
+  });
+
+  it("processes documents within the character ceiling", async () => {
+    generateText.mockReset();
+    // Pass one returns no candidates for the single chunk; normalization is
+    // then called and must finalize.
+    generateText
+      .mockResolvedValueOnce({
+        output: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+      })
+      .mockResolvedValueOnce({
+        steps: [
+          {
+            toolCalls: [{ toolName: "finalizeExtraction" }],
+          },
+        ],
+        usage: { inputTokens: 10, outputTokens: 5 },
+      });
+
+    const { payload } = buildPayload({
+      documentText: "We will build 100 hospitals.",
+      limits: { maxDocumentChars: 10_000 },
+    });
+
+    await runHandler(payload);
+
+    expect(generateText).toHaveBeenCalled();
+    // Every AI call must carry a per-call deadline.
+    for (const [args] of generateText.mock.calls) {
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
+      expect(args.maxRetries).toBe(0);
+    }
+
+    const processedUpdate = payload.update.mock.calls.find(
+      ([args]) => args.data?.fullyProcessed === true,
+    );
+    expect(processedUpdate).toBeDefined();
+  });
+});

--- a/tests/int/workflowLocks.int.spec.ts
+++ b/tests/int/workflowLocks.int.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Payload } from "payload";
+
+import {
+  acquireWorkflowLock,
+  releaseWorkflowLock,
+  WORKFLOW_LOCKS_COLLECTION,
+} from "@/lib/workflowLocks";
+
+const buildPayload = (
+  findOneAndUpdate: ReturnType<typeof vi.fn>,
+): Payload =>
+  ({
+    db: {
+      collections: {
+        [WORKFLOW_LOCKS_COLLECTION]: { findOneAndUpdate },
+      },
+    },
+  }) as unknown as Payload;
+
+describe("workflow run locks (duplicate scheduling guard)", () => {
+  it("acquires the lock when no other run holds it", async () => {
+    const findOneAndUpdate = vi.fn().mockReturnValue({
+      lean: () =>
+        Promise.resolve({ workflow: "airtableWorkflow", runId: "run-1" }),
+    });
+
+    const acquired = await acquireWorkflowLock(buildPayload(findOneAndUpdate), {
+      workflow: "airtableWorkflow",
+      runId: "run-1",
+    });
+
+    expect(acquired).toBe(true);
+
+    const [filter, update, options] = findOneAndUpdate.mock.calls[0];
+    expect(filter.workflow).toBe("airtableWorkflow");
+    expect(filter.$or).toBeDefined();
+    expect(update.$set.status).toBe("running");
+    expect(update.$set.expiresAt).toBeInstanceOf(Date);
+    expect(options).toMatchObject({ upsert: true, new: true });
+  });
+
+  it("refuses a duplicate run while another run holds a live lock", async () => {
+    // The atomic filter does not match a live "running" lock, so the second
+    // scheduler tick gets no document back.
+    const findOneAndUpdate = vi.fn().mockReturnValue({
+      lean: () => Promise.resolve(null),
+    });
+
+    const acquired = await acquireWorkflowLock(buildPayload(findOneAndUpdate), {
+      workflow: "airtableWorkflow",
+      runId: "run-2",
+    });
+
+    expect(acquired).toBe(false);
+  });
+
+  it("treats a duplicate-key upsert race as lock not acquired", async () => {
+    const duplicateKeyError = Object.assign(new Error("E11000"), {
+      code: 11000,
+    });
+    const findOneAndUpdate = vi.fn().mockReturnValue({
+      lean: () => Promise.reject(duplicateKeyError),
+    });
+
+    const acquired = await acquireWorkflowLock(buildPayload(findOneAndUpdate), {
+      workflow: "airtableWorkflow",
+      runId: "run-3",
+    });
+
+    expect(acquired).toBe(false);
+  });
+
+  it("takes over an expired lock from a crashed run", async () => {
+    const findOneAndUpdate = vi.fn().mockReturnValue({
+      lean: () =>
+        Promise.resolve({ workflow: "airtableWorkflow", runId: "run-4" }),
+    });
+
+    const acquired = await acquireWorkflowLock(buildPayload(findOneAndUpdate), {
+      workflow: "airtableWorkflow",
+      runId: "run-4",
+    });
+
+    expect(acquired).toBe(true);
+    const [filter] = findOneAndUpdate.mock.calls[0];
+    // Filter must allow acquiring when the previous lock expired.
+    expect(JSON.stringify(filter.$or)).toContain("expiresAt");
+  });
+
+  it("only releases a lock still owned by the releasing run", async () => {
+    const findOneAndUpdate = vi.fn().mockReturnValue({
+      lean: () => Promise.resolve(null),
+    });
+
+    await releaseWorkflowLock(buildPayload(findOneAndUpdate), {
+      workflow: "airtableWorkflow",
+      runId: "run-5",
+    });
+
+    const [filter, update] = findOneAndUpdate.mock.calls[0];
+    expect(filter).toMatchObject({
+      workflow: "airtableWorkflow",
+      runId: "run-5",
+      status: "running",
+    });
+    expect(update.$set.status).toBe("idle");
+  });
+});


### PR DESCRIPTION
Closes #577

## What changed

### Traceable extraction rows
- `extractions[].uniqueId` is now **required** and system-generated via a `beforeValidate` hook on the AIExtractions collection, so every extraction row can be matched to its downstream (Meedan/export) upload.
- `migrations/20260720_000001_backfill_ai_extraction_row_unique_ids.ts` safely backfills IDs onto existing rows (batched, idempotent, via a pure tested helper).

### Atomic overlap guard
- New hidden `workflow-locks` collection + `src/lib/workflowLocks.ts`. Acquisition is a single atomic `findOneAndUpdate` (upsert, unique index; a duplicate-key race counts as not acquired), with a 2h TTL so a crashed run's lock is taken over rather than blocking forever.
- `airtableWorkflow` (every-minute cron) acquires the lock at the start, releases in `finally`, and **skips** the run with a `workflow.overlap_skipped` Sentry log when a previous run still holds it — duplicate cron runs can no longer process the same work.

### Bounded AI calls
- New `src/lib/ai/extractionLimits.ts`: per-call timeout plus per-document duration/character/chunk/token/retry/cost ceilings, with safe defaults and per-deployment overrides in **Settings → Generative AI → Extraction Limits**.
- Every `generateText` call now runs through `runBoundedAICall`: per-call deadline via `AbortSignal.timeout`, SDK retries disabled, and our own bounded exponential backoff with full jitter that treats provider `Retry-After`/`retry-after-ms` guidance as a floor (`src/lib/ai/retry.ts`). Retry exhaustion is a typed `RetryExhaustedError`.
- `src/lib/ai/documentBudget.ts` accounts tokens and estimated USD cost per document and fails fast once any ceiling is crossed.

### Operator-reviewable state
- Documents gain an `extractionReview` sidebar group (`rejected` / `truncated` / `failed` + reason + timestamp). Oversized documents are rejected before any AI call; chunk/candidate truncation and budget/retry terminal failures are flagged; Airtable gets a `Needs Review: …` status. A clean successful run clears a stale flag.

### Metrics & alerting signals
Structured Sentry logs (via the existing task logger) suitable for alert rules: `ai.call.complete` (duration, retries, tokens, running budget), `ai.document.complete` (tokens, cost, calls, retries), `ai.document.review_flagged`, `ai.document.terminal_failure` (reason-coded), and `workflow.overlap_skipped` for pileups.

## Migrations
- Backfill of extraction-row unique IDs (verification + data fill; `down` is a no-op).

## Tests (25 new)
- `workflowLocks.int.spec.ts` — duplicate scheduling refused, upsert race, expired-lock takeover, owner-only release.
- `aiExtractionBounds.int.spec.ts` — limit resolution, duration/token/cost ceilings, provider timeout via AbortSignal, backoff shape, Retry-After floor, retry exhaustion, non-retryable passthrough.
- `aiExtractionUniqueIds.int.spec.ts` — required field + hook, missing/blank ID generation, backfill helper.
- `extractPromisesGuards.int.spec.ts` — oversized document rejected with zero AI calls; in-bounds document processed with deadline-carrying calls.
- Full int suite 147/147 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)