### PR TITLE
Build an approval-gated production release pipeline

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,122 @@
+name: Build image
+
+# Reusable image build. Builds the immutable runtime and migrator images ONCE
+# from the current commit and pushes them to the registry. Downstream deploy
+# jobs promote the exact images by DIGEST (never by mutable tag), so staging
+# and production run bit-for-bit what was built and verified here.
+#
+# Production artifact creation does not require a reachable database: the
+# Dockerfile defaults DATABASE_URI/PAYLOAD_SECRET to build-time placeholders.
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+      next_public_app_url:
+        required: true
+        type: string
+      sentry_environment:
+        required: true
+        type: string
+      platforms:
+        required: false
+        type: string
+        default: linux/arm64
+    outputs:
+      runtime_image:
+        description: "Immutable runtime image reference pinned by digest"
+        value: ${{ jobs.build.outputs.runtime_image }}
+      migrator_image:
+        description: "Immutable migrator image reference pinned by digest"
+        value: ${{ jobs.build.outputs.migrator_image }}
+      runtime_digest:
+        description: "Runtime image digest"
+        value: ${{ jobs.build.outputs.runtime_digest }}
+    secrets:
+      DOCKER_HUB_USERNAME:
+        required: true
+      DOCKER_HUB_ACCESS_TOKEN:
+        required: true
+      SENTRY_DSN:
+        required: false
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_ORG:
+        required: false
+      SENTRY_PROJECT:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime_image: ${{ steps.refs.outputs.runtime_image }}
+      migrator_image: ${{ steps.refs.outputs.migrator_image }}
+      runtime_digest: ${{ steps.build_runtime.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # Build the runtime image once. No real/reachable database is required.
+      - name: Build and push runtime image
+        id: build_runtime
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runner
+          platforms: ${{ inputs.platforms }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_APP_URL=${{ inputs.next_public_app_url }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+            SENTRY_ENVIRONMENT=${{ inputs.sentry_environment }}
+          secrets: |
+            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
+            "sentry_org=${{ secrets.SENTRY_ORG }}"
+            "sentry_project=${{ secrets.SENTRY_PROJECT }}"
+          tags: "${{ inputs.image_name }}:${{ github.sha }}"
+
+      # Build the migrator image from the same commit for the release migrate step.
+      - name: Build and push migrator image
+        id: build_migrator
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: migrator
+          platforms: ${{ inputs.platforms }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: "${{ inputs.image_name }}-migrator:${{ github.sha }}"
+
+      # Pin both images by digest so downstream jobs promote the exact bytes.
+      - name: Compute immutable image references
+        id: refs
+        run: |
+          echo "runtime_image=${{ inputs.image_name }}@${{ steps.build_runtime.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "migrator_image=${{ inputs.image_name }}-migrator@${{ steps.build_migrator.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize
+        run: |
+          {
+            echo "### Built images"
+            echo "- runtime: \`${{ inputs.image_name }}@${{ steps.build_runtime.outputs.digest }}\`"
+            echo "- migrator: \`${{ inputs.image_name }}-migrator@${{ steps.build_migrator.outputs.digest }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -47,6 +47,11 @@ on:
       SENTRY_PROJECT:
         required: false
 
+# Least-privilege default for GITHUB_TOKEN; the build only reads repo contents
+# and pushes to the registry via dedicated secrets.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,69 +13,41 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  APP_NAME: promisetracker-v2
-  DOKKU_REMOTE_BRANCH: "master"
-  DOKKU_REMOTE_URL: "ssh://azureuser@ui-1.dev.codeforafrica.org"
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  IMAGE_NAME: "codeforafrica/promisetracker-v2"
-  NEXT_PUBLIC_APP_URL: "https://promisetracker-v2.dev.codeforafrica.org"
-  SENTRY_ENVIRONMENT: "development"
-
 jobs:
   # Mandatory verification gate. Deployment cannot run when this fails.
   verify:
     uses: ./.github/workflows/verify.yml
 
-  deploy:
+  # Build the immutable runtime + migrator images once (no reachable DB needed).
+  build:
     needs: verify
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [20.16]
-        os: [ubuntu-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image_name: "codeforafrica/promisetracker-v2"
+      next_public_app_url: "https://promisetracker-v2.dev.codeforafrica.org"
+      sentry_environment: "development"
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-      # Add support for more platforms with QEMU (optional)
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          build-args: |
-            NEXT_PUBLIC_APP_URL=${{ env.NEXT_PUBLIC_APP_URL }}
-            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-            SENTRY_ENVIRONMENT=${{ env.SENTRY_ENVIRONMENT }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          context: .
-          platforms: linux/arm64
-          push: true
-          secrets: |
-            "database_uri=${{ secrets.DATABASE_URI }}"
-            "payload_secret=${{ secrets.PAYLOAD_SECRET }}"
-            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
-            "sentry_org=${{ secrets.SENTRY_ORG }}"
-            "sentry_project=${{ secrets.SENTRY_PROJECT }}"
-          tags: "${{ env.IMAGE_NAME }}:${{ github.sha }}"
-
-      - name: Push to Dokku
-        uses: dokku/github-action@v1.7.0
-        with:
-          git_remote_url: ${{ env.DOKKU_REMOTE_URL }}/${{ env.APP_NAME }}
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          deploy_docker_image: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+  # Migrate once, then promote the exact digest, then verify readiness.
+  deploy:
+    needs: build
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: development
+      app_name: promisetracker-v2
+      dokku_remote_url: "ssh://azureuser@ui-1.dev.codeforafrica.org"
+      app_url: "https://promisetracker-v2.dev.codeforafrica.org"
+      runtime_image: ${{ needs.build.outputs.runtime_image }}
+      migrator_image: ${{ needs.build.outputs.migrator_image }}
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      DATABASE_URI: ${{ secrets.DATABASE_URI }}
+      PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -47,6 +47,11 @@ on:
       PAYLOAD_SECRET:
         required: true
 
+# Least-privilege default for GITHUB_TOKEN; the deploy authenticates to
+# DockerHub/Dokku via dedicated secrets, not the workflow token.
+permissions:
+  contents: read
+
 jobs:
   promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,103 @@
+name: Promote
+
+# Reusable deploy step. Promotes a previously-built, immutable image (pinned by
+# digest) to a GitHub environment. The environment gates the job: configure
+# "required reviewers" on the `production` environment in repo settings to make
+# production deployment require human approval.
+#
+# Order of operations enforces the release invariants:
+#   1. Migrations run ONCE, in a single one-off container (never in every
+#      replica). If they fail, the job fails here and traffic is never switched.
+#   2. Only then is the runtime image promoted (traffic switch).
+#   3. A bounded post-deploy readiness check confirms the new instance serves.
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      app_name:
+        required: true
+        type: string
+      dokku_remote_url:
+        required: true
+        type: string
+      app_url:
+        required: true
+        type: string
+      runtime_image:
+        required: true
+        type: string
+      migrator_image:
+        required: true
+        type: string
+      run_migrations:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      SSH_PRIVATE_KEY:
+        required: true
+      DOCKER_HUB_USERNAME:
+        required: true
+      DOCKER_HUB_ACCESS_TOKEN:
+        required: true
+      DATABASE_URI:
+        required: true
+      PAYLOAD_SECRET:
+        required: true
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.app_url }}
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # Single-instance, observable migration step. Runs the migrator image
+      # built from the same commit. A non-zero exit fails the job BEFORE the
+      # promote step below, so traffic is never switched onto an un-migrated or
+      # partially-migrated database. See docs/deployment/release-pipeline.md for
+      # forward-fix / rollback handling on failure.
+      - name: Run database migrations (once)
+        if: ${{ inputs.run_migrations }}
+        env:
+          DATABASE_URI: ${{ secrets.DATABASE_URI }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+        run: |
+          docker run --rm \
+            -e DATABASE_URI \
+            -e PAYLOAD_SECRET \
+            -e TIKA_ENABLED=0 \
+            "${{ inputs.migrator_image }}"
+
+      # Promote the EXACT runtime image (by digest) that was built and verified.
+      - name: Deploy runtime image to Dokku
+        uses: dokku/github-action@v1.7.0
+        with:
+          git_remote_url: ${{ inputs.dokku_remote_url }}/${{ inputs.app_name }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          deploy_docker_image: ${{ inputs.runtime_image }}
+
+      # Bounded post-deploy readiness gate: fail the release if the new instance
+      # does not become ready (Mongo + Tika) within the window.
+      - name: Verify readiness
+        run: |
+          url="${{ inputs.app_url }}/api/health/ready"
+          for attempt in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "Ready after ${attempt} attempt(s)."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: readiness returned ${code}; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::${{ inputs.environment }} did not become ready in time."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ concurrency:
   group: "release-production"
   cancel-in-progress: false
 
+# Least-privilege default for GITHUB_TOKEN across all jobs.
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: "codeforafrica/promisetracker-v2"
   DOKKU_REMOTE_URL: "ssh://azureuser@ui-1.dev.codeforafrica.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Promise Tracker | Release | Production
+
+# Approval-gated production release. Builds ONE immutable image, verifies it,
+# promotes the exact digest to staging, then (after human approval on the
+# `production` GitHub environment) runs migrations once and promotes the SAME
+# digest to production.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      skip_staging:
+        description: "Promote straight to production (skip staging)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: "release-production"
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: "codeforafrica/promisetracker-v2"
+  DOKKU_REMOTE_URL: "ssh://azureuser@ui-1.dev.codeforafrica.org"
+
+jobs:
+  # Mandatory verification gate (lint, types, integration + E2E, SCA).
+  verify:
+    uses: ./.github/workflows/verify.yml
+
+  build:
+    needs: verify
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image_name: "codeforafrica/promisetracker-v2"
+      next_public_app_url: "https://promisetracker.codeforafrica.org"
+      sentry_environment: "production"
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
+  staging:
+    needs: build
+    if: ${{ !inputs.skip_staging }}
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: staging
+      app_name: promisetracker-v2-staging
+      dokku_remote_url: "ssh://azureuser@ui-1.dev.codeforafrica.org"
+      app_url: "https://promisetracker-v2.staging.codeforafrica.org"
+      runtime_image: ${{ needs.build.outputs.runtime_image }}
+      migrator_image: ${{ needs.build.outputs.migrator_image }}
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      DATABASE_URI: ${{ secrets.STAGING_DATABASE_URI }}
+      PAYLOAD_SECRET: ${{ secrets.STAGING_PAYLOAD_SECRET }}
+
+  # Requires approval on the `production` environment (configure required
+  # reviewers in repo settings). `always() && !failure() && !cancelled()` lets
+  # production proceed whether or not staging was skipped, but never after a
+  # failure upstream.
+  production:
+    needs: [build, staging]
+    if: ${{ always() && !failure() && !cancelled() }}
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: production
+      app_name: promisetracker-v2
+      dokku_remote_url: "ssh://azureuser@ui-1.dev.codeforafrica.org"
+      app_url: "https://promisetracker.codeforafrica.org"
+      runtime_image: ${{ needs.build.outputs.runtime_image }}
+      migrator_image: ${{ needs.build.outputs.migrator_image }}
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      DATABASE_URI: ${{ secrets.DATABASE_URI }}
+      PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,34 @@ ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 
+# The build imports payload.config (which requires DATABASE_URI/PAYLOAD_SECRET
+# to be present) but never opens a database connection. Both default to
+# build-time placeholders, so producing the production artifact does NOT
+# require a reachable — or even real — application database. Real runtime
+# values are supplied to the container at deploy time, not baked into the image.
 RUN --mount=type=secret,id=database_uri,env=DATABASE_URI \
     --mount=type=secret,id=payload_secret,env=PAYLOAD_SECRET \
     --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
     --mount=type=secret,id=sentry_org,env=SENTRY_ORG \
     --mount=type=secret,id=sentry_project,env=SENTRY_PROJECT \
+    : "${DATABASE_URI:=mongodb://build-placeholder:27017/build}"; \
+    : "${PAYLOAD_SECRET:=build-time-placeholder-secret}"; \
+    export DATABASE_URI PAYLOAD_SECRET; \
     NODE_OPTIONS="--no-deprecation" pnpm exec next build
+
+# Migrator image: the same source and dependencies as the build, but retaining
+# the Payload CLI and migrations/ directory (which the slim standalone runner
+# prunes). Run as a single one-off container during the release to execute
+# `payload migrate` exactly once before traffic switches — never in every
+# runtime replica.
+FROM base AS migrator
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    TIKA_ENABLED=0
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+CMD ["pnpm", "migrate"]
 
 # Production image, copy all the files and run next
 FROM base AS runner
@@ -76,6 +98,13 @@ RUN mkdir -p /app/temp /app/media \
 USER nextjs
 
 EXPOSE 3000
+
+# Liveness probe: process is up and serving. Intentionally hits the
+# dependency-free /api/health/live endpoint so a Mongo/Tika outage never
+# causes the container to be killed. Readiness (Mongo + Tika) is checked
+# separately by the platform via /api/health/ready.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl --silent --fail --max-time 4 "http://127.0.0.1:${PORT}/api/health/live" || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/app.json
+++ b/app.json
@@ -1,0 +1,34 @@
+{
+  "name": "promisetracker",
+  "description": "PromiseTracker CMS + frontend. Health probes are wired to the bounded liveness/readiness endpoints served by the app.",
+  "healthchecks": {
+    "web": [
+      {
+        "name": "startup probe",
+        "type": "startup",
+        "path": "/api/health/live",
+        "attempts": 10,
+        "initialDelay": 15,
+        "wait": 5,
+        "timeout": 5
+      },
+      {
+        "name": "liveness probe",
+        "type": "liveness",
+        "path": "/api/health/live",
+        "attempts": 3,
+        "wait": 30,
+        "timeout": 5,
+        "onFailure": "restart"
+      },
+      {
+        "name": "readiness probe",
+        "type": "readiness",
+        "path": "/api/health/ready",
+        "attempts": 3,
+        "wait": 10,
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/docs/deployment/release-pipeline.md
+++ b/docs/deployment/release-pipeline.md
@@ -1,0 +1,98 @@
+# Production release pipeline
+
+PromiseTracker uses an **approval-gated, build-once/promote-by-digest** release
+flow. The same immutable image that CI builds and verifies is the exact image
+that runs in staging and production — nothing is rebuilt between environments.
+
+## Pipeline shape
+
+```
+verify ──▶ build (once) ──▶ staging ──▶ production (approval)
+             │                 │              │
+             │                 │              ├─ migrate once
+             │                 │              ├─ promote runtime digest
+             │                 │              └─ readiness gate
+             │                 └─ migrate once → promote digest → readiness
+             └─ runtime + migrator images, pinned by digest
+```
+
+Workflows:
+
+- [`verify.yml`](../../.github/workflows/verify.yml) — lint, type-check,
+  integration + E2E tests, dependency scan. Mandatory gate.
+- [`build-image.yml`](../../.github/workflows/build-image.yml) — builds the
+  `runner` and `migrator` images **once** and outputs each pinned by digest
+  (`image@sha256:…`).
+- [`promote.yml`](../../.github/workflows/promote.yml) — reusable deploy: run
+  migrations once, promote the runtime digest, verify readiness. Bound to a
+  GitHub environment.
+- [`release.yml`](../../.github/workflows/release.yml) — orchestrates
+  verify → build → staging → production for `v*` tags (or manual dispatch).
+- [`deploy-dev.yml`](../../.github/workflows/deploy-dev.yml) — the same pattern
+  for the auto-deployed dev environment on pushes to `main`.
+
+## Invariants
+
+### Build does not require a database
+
+`next build` imports `payload.config.ts` (which requires `DATABASE_URI` and
+`PAYLOAD_SECRET` to be *present*) but never opens a connection. The Dockerfile
+defaults both to build-time placeholders, so **producing the artifact needs no
+reachable — or even real — database**. Real values are injected into the
+container at deploy time, never baked into the image.
+
+### One immutable image, promoted by digest
+
+`build-image.yml` pushes `codeforafrica/promisetracker-v2:<sha>` and resolves
+its content digest. Every downstream deploy references
+`codeforafrica/promisetracker-v2@sha256:<digest>`, so staging and production
+run bit-for-bit identical artifacts. Mutable tags are never deployed.
+
+### Production requires human approval
+
+The `production` job runs in the GitHub `production` environment. Configure
+**Settings → Environments → production → Required reviewers** so the job pauses
+for approval before any production change (including migrations).
+
+### Migrations run once, before traffic switches
+
+Migrations run as a **single one-off container** from the `migrator` image
+(`pnpm migrate`), never inside every runtime replica (the entrypoint does not
+run migrations). The migrate step runs *before* the promote step in the same
+job; a migration failure fails the job and **traffic is never switched**.
+
+### Bounded liveness and readiness probes
+
+- `GET /api/health/live` — process-only liveness; no dependency calls. Wired to
+  the Docker `HEALTHCHECK` and the Dokku `liveness` probe.
+- `GET /api/health/ready` — checks MongoDB (mongoose ping) and Apache Tika
+  (HTTP, when `TIKA_ENABLED != 0`), each time-bounded. Returns `503` until the
+  instance can serve. Wired to the Dokku `readiness`/`startup` probes in
+  [`app.json`](../../app.json) and used as the post-deploy gate in `promote.yml`.
+
+## On migration failure
+
+The promote job stops at the migrate step; the runtime image is **not**
+promoted, so live traffic continues to run the previous release against the
+unchanged (or partially-changed) database.
+
+1. **Forward-fix (preferred for additive migrations):** correct the migration,
+   cut a new tag, and re-run the release. Additive changes (new fields,
+   backfills that are safe to re-run) should be idempotent.
+2. **Rollback (for destructive/failed migrations):** restore the database from
+   the pre-release backup and redeploy the previous image digest. See
+   [rollback-and-restore.md](./rollback-and-restore.md).
+
+Always take a database backup immediately before approving a production release
+that includes migrations (the rollback runbook shows the command).
+
+## Required repository configuration
+
+Secrets: `DOCKER_HUB_USERNAME`, `DOCKER_HUB_ACCESS_TOKEN`, `SSH_PRIVATE_KEY`,
+`DATABASE_URI`, `PAYLOAD_SECRET` (production), `STAGING_DATABASE_URI`,
+`STAGING_PAYLOAD_SECRET`, and the `SENTRY_*` set. Environments: `development`,
+`staging`, `production` (with required reviewers on `production`).
+
+> Note: the migrate step and readiness gate assume the GitHub runner can reach
+> the target database and app URL. If the environments are network-isolated,
+> run the migrator image via `dokku run` on the host instead — see the runbook.

--- a/docs/deployment/rollback-and-restore.md
+++ b/docs/deployment/rollback-and-restore.md
@@ -1,0 +1,88 @@
+# Rollback and database restore runbook
+
+This runbook covers reverting a bad production release: rolling the running
+image back to a known-good digest, and restoring the database from a backup.
+Because releases promote images **by digest** (see
+[release-pipeline.md](./release-pipeline.md)), rollback is deterministic — every
+prior release is an immutable, addressable artifact.
+
+## Before every release with migrations
+
+Take a database backup so a destructive migration can be undone:
+
+```sh
+# On the database host (or any host with network access + mongo tools):
+mongodump --uri="$DATABASE_URI" --archive="pt-$(date -u +%Y%m%dT%H%M%SZ).gz" --gzip
+```
+
+Keep the archive until the release has been confirmed healthy.
+
+## Image rollback
+
+Every deployed release is `codeforafrica/promisetracker-v2@sha256:<digest>`.
+Find the previous good digest from the release run summary (or the registry /
+`dokku` deploy history), then redeploy it:
+
+```sh
+# Redeploy a specific known-good digest (no rebuild required):
+dokku git:from-image promisetracker-v2 \
+  codeforafrica/promisetracker-v2@sha256:<previous-digest>
+```
+
+The new (bad) instance is only serving traffic if it passed the readiness gate;
+rolling back re-promotes the previous digest and Dokku's zero-downtime checks
+(from [`app.json`](../../app.json)) hold traffic until the rolled-back instance
+is ready again.
+
+## Database restore
+
+If a migration corrupted or destructively changed data, restore from the
+pre-release backup:
+
+```sh
+mongorestore --uri="$DATABASE_URI" --gzip --archive="pt-<timestamp>.gz" --drop
+```
+
+`--drop` replaces each collection in the archive so the restore is clean. Do the
+image rollback and the database restore together when the bad release included a
+schema/data migration.
+
+## Rehearsal
+
+These procedures were rehearsed locally on 2026-07-20 against `mongo:7` and the
+Docker digest mechanism:
+
+**Database dump → simulated loss → restore**
+
+```
+seeded: 1
+dump OK
+after drop: 0
+restore OK
+after restore: 1
+{ title: 'pledge-1', v: 1 }
+```
+
+The seeded document survived a full `mongodump` → `drop` → `mongorestore --drop`
+cycle — data was recovered exactly.
+
+**Image-by-digest rollback**
+
+```
+pinned digest ref: alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+ran exact image by digest: OK
+```
+
+Running a container by immutable digest reference succeeds, confirming that any
+prior release digest can be re-run deterministically without a rebuild.
+
+> The rehearsal validated the mechanics (backup/restore fidelity and digest
+> pinning). A full production rehearsal should additionally exercise the Dokku
+> `git:from-image` redeploy against the staging app before relying on it for a
+> real incident.
+
+## Post-rollback checklist
+
+1. Confirm `GET /api/health/ready` returns `200` on the rolled-back instance.
+2. Confirm the database document counts / spot-checks match the backup.
+3. Open a follow-up to forward-fix the migration before re-attempting release.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,11 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { withSentryConfig } from "@sentry/nextjs";
 import { withPayload } from "@payloadcms/next/withPayload";
 
 import { buildSecurityHeaders } from "./src/lib/security/headers.mjs";
+
+const projectDir = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -10,6 +14,11 @@ const nextConfig = {
     ignoreDuringBuilds: false,
   },
   output: "standalone",
+  // Pin the standalone tracing root to this project so `.next/standalone/
+  // server.js` lands at a deterministic path (matches the Dockerfile's
+  // `COPY .next/standalone ./`). Without this, a parent directory holding
+  // another lockfile (e.g. a git worktree) makes Next infer the wrong root.
+  outputFileTracingRoot: projectDir,
   async headers() {
     return [
       {

--- a/src/app/(frontend)/[...slugs]/page.tsx
+++ b/src/app/(frontend)/[...slugs]/page.tsx
@@ -25,6 +25,9 @@ import {
   resolvePublicRoute,
 } from "@/lib/routes/publicRoutes";
 import { resolveTenantLocale } from "@/utils/locales";
+
+// Multi-tenant, subdomain-resolved route — never statically prerendered.
+export const dynamic = "force-dynamic";
 import { resolveBrowserLocale } from "@/lib/locale";
 import type { EntityPage } from "@/payload-types";
 import type { MenuLink } from "@/types/navigation";

--- a/src/app/(frontend)/[entitySlug]/promises/[promiseId]/page.tsx
+++ b/src/app/(frontend)/[entitySlug]/promises/[promiseId]/page.tsx
@@ -37,6 +37,9 @@ import type {
 } from "@/payload-types";
 import { resolveTenantLocale } from "@/utils/locales";
 
+// Multi-tenant, subdomain-resolved route — never statically prerendered.
+export const dynamic = "force-dynamic";
+
 const FALLBACK_STATUS_COLOR = "#909090";
 const FALLBACK_STATUS_TEXT_COLOR = "#202020";
 

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -9,6 +9,12 @@ import { resolveBrowserLocale } from "@/lib/locale";
 import { getTenantBySubDomain } from "@/lib/data/tenants";
 import { resolveTenantLocale } from "@/utils/locales";
 
+// This layout resolves the tenant from the request subdomain (a DB lookup),
+// so the whole (frontend) segment is dynamic and must never be statically
+// prerendered. This also keeps `next build` from connecting to MongoDB while
+// collecting page data.
+export const dynamic = "force-dynamic";
+
 const inter = Inter({
   subsets: ["latin"],
   weight: ["300", "400", "600", "700"],

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,3 +1,6 @@
 import PageTemplate from "./[...slugs]/page";
 
+// Multi-tenant, subdomain-resolved page — never statically prerendered.
+export const dynamic = "force-dynamic";
+
 export default PageTemplate;

--- a/src/app/api/health/live/route.ts
+++ b/src/app/api/health/live/route.ts
@@ -1,0 +1,17 @@
+/**
+ * GET /api/health/live — liveness probe.
+ *
+ * Answers only "is the Node process up and serving?". It deliberately does
+ * NOT touch MongoDB, Tika, or any other dependency, so a dependency outage
+ * can never cause the orchestrator to kill an otherwise-healthy process.
+ */
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const GET = () =>
+  NextResponse.json(
+    { status: "ok" },
+    { status: 200, headers: { "Cache-Control": "no-store" } },
+  );

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /api/health/ready — readiness probe.
+ *
+ * Answers "can this instance serve traffic right now?" by checking the
+ * dependencies required to serve: MongoDB and (when enabled) Apache Tika.
+ * Each check is time-bounded. Returns 200 when ready, 503 otherwise, so
+ * Dokku/Docker probes hold traffic off an instance that cannot serve.
+ */
+import { NextResponse } from "next/server";
+import { getGlobalPayload } from "@/lib/payload";
+import { checkMongo, checkTika, summarizeReadiness } from "@/lib/health";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const GET = async () => {
+  const checks = [];
+
+  try {
+    const payload = await getGlobalPayload();
+    checks.push(await checkMongo(payload as never));
+  } catch (error) {
+    checks.push({
+      name: "mongodb",
+      ok: false,
+      required: true,
+      durationMs: 0,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  checks.push(await checkTika());
+
+  const summary = summarizeReadiness(checks);
+
+  return NextResponse.json(summary, {
+    status: summary.ready ? 200 : 503,
+    headers: { "Cache-Control": "no-store" },
+  });
+};

--- a/src/components/Newsletter/Newsletter.tsx
+++ b/src/components/Newsletter/Newsletter.tsx
@@ -19,9 +19,12 @@ import { getGlobalPayload } from "@/lib/payload";
 import { resolveTenantLocale } from "@/utils/locales";
 import { resolveBrowserLocale } from "@/lib/locale";
 
-const payload = await getGlobalPayload();
-
 const Newsletter = async ({ image }: NewsletterBlockProps) => {
+  // Resolved lazily (memoized), never at module top-level — a top-level await
+  // would connect to MongoDB just by importing this component, which the
+  // BlockRenderer does at build time and would force `next build` to require
+  // a reachable database.
+  const payload = await getGlobalPayload();
   const { subdomain } = await getDomain();
   const tenant = await getTenantBySubDomain(subdomain);
   const locale = tenant

--- a/src/lib/data/politicalEntities.ts
+++ b/src/lib/data/politicalEntities.ts
@@ -6,12 +6,13 @@ import type {
 } from "@/payload-types";
 import type { PayloadLocale } from "@/utils/locales";
 
-const payload = await getGlobalPayload();
-
+// Resolved lazily per-call (memoized) rather than at module top-level, so
+// importing this module does not open a MongoDB connection at build time.
 export const getPoliticalEntitiesByTenant = async (
   tenant: Tenant,
   locale?: PayloadLocale,
 ): Promise<PoliticalEntity[]> => {
+  const payload = await getGlobalPayload();
   const { docs } = await payload.find({
     collection: "political-entities",
     limit: 0,
@@ -42,6 +43,7 @@ export const getPoliticalEntityBySlug = async (
   slug: string,
   locale?: PayloadLocale,
 ): Promise<PoliticalEntity | undefined> => {
+  const payload = await getGlobalPayload();
   const { docs } = await payload.find({
     collection: "political-entities",
     limit: 1,
@@ -86,6 +88,7 @@ export const getPromiseCountsForEntities = async (
     return {};
   }
 
+  const payload = await getGlobalPayload();
   const counts = entityIds.reduce<
     Record<
       string,

--- a/src/lib/data/promiseUpdates.ts
+++ b/src/lib/data/promiseUpdates.ts
@@ -3,10 +3,11 @@ import type { PromiseUpdateSettings } from "@/types/promiseUpdates";
 import type { Media } from "@/payload-types";
 import type { PayloadLocale } from "@/utils/locales";
 
-const payload = await getGlobalPayload();
-
+// Resolved lazily per-call (memoized) rather than at module top-level, so
+// importing this module does not open a MongoDB connection at build time.
 export const getPromiseUpdateEmbed =
   async (locale?: PayloadLocale): Promise<PromiseUpdateSettings | null> => {
+    const payload = await getGlobalPayload();
     try {
       const doc = await payload.findGlobal({
         slug: "promise-updates",

--- a/src/lib/data/promises.ts
+++ b/src/lib/data/promises.ts
@@ -1,7 +1,8 @@
 import { getGlobalPayload } from "@/lib/payload";
 import type { Promise as PromiseDocument } from "@/payload-types";
 
-const payload = await getGlobalPayload();
+// Resolved lazily per-call (memoized) rather than at module top-level, so
+// importing this module does not open a MongoDB connection at build time.
 
 type GetPromiseByIdOptions = {
   locale?: "en" | "fr";
@@ -12,6 +13,7 @@ export const getPromiseById = async (
   options: GetPromiseByIdOptions = {}
 ): Promise<PromiseDocument | null> => {
   const { locale } = options;
+  const payload = await getGlobalPayload();
 
   try {
     const doc = await payload.findByID({

--- a/src/lib/data/tenants.ts
+++ b/src/lib/data/tenants.ts
@@ -8,11 +8,14 @@ import type {
 import type { Media, Page, SiteSetting, Tenant } from "@/payload-types";
 import type { PayloadLocale } from "@/utils/locales";
 
-const payload = await getGlobalPayload();
-
+// getGlobalPayload() is resolved lazily inside each function (it is memoized),
+// never at module top-level — a top-level await opens a MongoDB connection
+// merely by importing this module, which makes `next build` require a
+// reachable database.
 export const getAllTenants = async (): Promise<
   (Tenant & { flag?: string | null })[]
 > => {
+  const payload = await getGlobalPayload();
   const { docs } = await payload.find({
     collection: "tenants",
     where: {
@@ -41,6 +44,7 @@ export const getTenantSiteSettings = async (
   tenant: Tenant,
   locale?: PayloadLocale,
 ) => {
+  const payload = await getGlobalPayload();
   const { docs } = await payload.find({
     collection: "site-settings",
     where: {
@@ -90,6 +94,7 @@ export const getTenantNavigation = async (
   tenant?: Tenant,
   locale?: PayloadLocale,
 ) => {
+  const payload = await getGlobalPayload();
   let tenantSettings = null;
   if (tenant) {
     tenantSettings = await getTenantSiteSettings(tenant, locale);

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,0 +1,138 @@
+/**
+ * Bounded health checks for the liveness and readiness endpoints.
+ *
+ * Liveness answers "is the process up?" and must never depend on external
+ * services. Readiness answers "can this instance serve traffic right now?"
+ * and checks the dependencies that are required to serve — MongoDB and (when
+ * enabled) Apache Tika. Every dependency check is time-bounded so a hung
+ * dependency can never hang the probe itself.
+ */
+
+export type DependencyStatus = {
+  name: string;
+  ok: boolean;
+  required: boolean;
+  durationMs: number;
+  error?: string;
+};
+
+export const DEFAULT_HEALTH_TIMEOUT_MS = 2_000;
+
+const withTimeout = async <T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+): Promise<T> => {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout>;
+  // Race the operation against the deadline so a dependency that ignores the
+  // AbortSignal (e.g. a hung driver call) still cannot outlast the timeout.
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+};
+
+const timed = async (
+  name: string,
+  required: boolean,
+  check: () => Promise<void>,
+): Promise<DependencyStatus> => {
+  const startedAt = Date.now();
+  try {
+    await check();
+    return { name, ok: true, required, durationMs: Date.now() - startedAt };
+  } catch (error) {
+    return {
+      name,
+      ok: false,
+      required,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};
+
+type MongoPinger = {
+  db?: {
+    connection?: {
+      readyState?: number;
+      db?: { admin: () => { command: (cmd: Record<string, number>) => Promise<unknown> } };
+    };
+  };
+};
+
+/**
+ * Pings MongoDB through the Payload mongoose connection. Bounded by
+ * `timeoutMs`; a disconnected or unreachable database resolves to `ok: false`.
+ */
+export const checkMongo = (
+  payload: MongoPinger,
+  timeoutMs = DEFAULT_HEALTH_TIMEOUT_MS,
+): Promise<DependencyStatus> =>
+  timed("mongodb", true, async () => {
+    const connection = payload.db?.connection;
+    if (!connection) {
+      throw new Error("no mongoose connection on payload adapter");
+    }
+    // 1 === connected (mongoose ConnectionStates).
+    if (connection.readyState !== 1) {
+      throw new Error(`mongoose connection not ready (state ${connection.readyState})`);
+    }
+    const admin = connection.db?.admin();
+    if (!admin) {
+      throw new Error("mongoose connection has no database handle");
+    }
+    await withTimeout(async () => {
+      await admin.command({ ping: 1 });
+    }, timeoutMs);
+  });
+
+/**
+ * Checks Apache Tika readiness via an HTTP GET to its health path. Skipped
+ * (reported ok, not required) when Tika is disabled via TIKA_ENABLED=0.
+ */
+export const checkTika = (
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = DEFAULT_HEALTH_TIMEOUT_MS,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DependencyStatus> => {
+  const enabled = env.TIKA_ENABLED !== "0";
+  if (!enabled) {
+    return Promise.resolve({
+      name: "tika",
+      ok: true,
+      required: false,
+      durationMs: 0,
+    });
+  }
+
+  const baseUrl = env.AX_APACHE_TIKA_URL ?? "http://127.0.0.1:9998/";
+  const healthPath = env.TIKA_HEALTH_PATH ?? "/tika";
+  const url = new URL(healthPath, baseUrl).toString();
+
+  return timed("tika", true, async () => {
+    const response = await withTimeout(
+      (signal) => fetchImpl(url, { method: "GET", signal }),
+      timeoutMs,
+    );
+    if (!response.ok) {
+      throw new Error(`tika responded with HTTP ${response.status}`);
+    }
+  });
+};
+
+export const summarizeReadiness = (checks: DependencyStatus[]) => {
+  const ready = checks.every((check) => check.ok || !check.required);
+  return {
+    status: ready ? ("ok" as const) : ("unavailable" as const),
+    ready,
+    checks,
+  };
+};

--- a/tests/int/health.int.spec.ts
+++ b/tests/int/health.int.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { checkMongo, checkTika, summarizeReadiness } from "@/lib/health";
+
+const mongoPayload = (readyState: number, ping?: () => Promise<unknown>) => ({
+  db: {
+    connection: {
+      readyState,
+      db: {
+        admin: () => ({
+          command: ping ?? (() => Promise.resolve({ ok: 1 })),
+        }),
+      },
+    },
+  },
+});
+
+describe("checkMongo", () => {
+  it("reports ok when connected and ping succeeds", async () => {
+    const status = await checkMongo(mongoPayload(1));
+    expect(status).toMatchObject({ name: "mongodb", ok: true, required: true });
+  });
+
+  it("reports not-ok when the connection is not ready", async () => {
+    const status = await checkMongo(mongoPayload(0));
+    expect(status.ok).toBe(false);
+    expect(status.error).toMatch(/not ready/);
+  });
+
+  it("reports not-ok when there is no connection", async () => {
+    const status = await checkMongo({ db: {} });
+    expect(status.ok).toBe(false);
+    expect(status.error).toMatch(/no mongoose connection/);
+  });
+
+  it("is bounded and fails when the ping hangs past the timeout", async () => {
+    const hanging = () => new Promise(() => {});
+    const status = await checkMongo(mongoPayload(1, hanging), 20);
+    expect(status.ok).toBe(false);
+    expect(status.durationMs).toBeLessThan(1_000);
+  });
+});
+
+describe("checkTika", () => {
+  it("is skipped and non-required when Tika is disabled", async () => {
+    const status = await checkTika({ TIKA_ENABLED: "0" } as never);
+    expect(status).toMatchObject({ name: "tika", ok: true, required: false });
+  });
+
+  it("reports ok when Tika responds 200", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const status = await checkTika(
+      {
+        TIKA_ENABLED: "1",
+        AX_APACHE_TIKA_URL: "http://tika:9998/",
+      } as never,
+      2_000,
+      fetchImpl as never,
+    );
+    expect(status).toMatchObject({ name: "tika", ok: true, required: true });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://tika:9998/tika",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("reports not-ok when Tika responds non-2xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const status = await checkTika(
+      { TIKA_ENABLED: "1" } as never,
+      2_000,
+      fetchImpl as never,
+    );
+    expect(status.ok).toBe(false);
+    expect(status.error).toMatch(/HTTP 503/);
+  });
+
+  it("reports not-ok when the Tika request rejects", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const status = await checkTika(
+      { TIKA_ENABLED: "1" } as never,
+      2_000,
+      fetchImpl as never,
+    );
+    expect(status.ok).toBe(false);
+    expect(status.error).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe("summarizeReadiness", () => {
+  it("is ready when all required checks pass", () => {
+    const summary = summarizeReadiness([
+      { name: "mongodb", ok: true, required: true, durationMs: 1 },
+      { name: "tika", ok: true, required: true, durationMs: 1 },
+    ]);
+    expect(summary).toMatchObject({ status: "ok", ready: true });
+  });
+
+  it("is unavailable when a required check fails", () => {
+    const summary = summarizeReadiness([
+      { name: "mongodb", ok: false, required: true, durationMs: 1 },
+      { name: "tika", ok: true, required: true, durationMs: 1 },
+    ]);
+    expect(summary).toMatchObject({ status: "unavailable", ready: false });
+  });
+
+  it("stays ready when only a non-required check fails", () => {
+    const summary = summarizeReadiness([
+      { name: "mongodb", ok: true, required: true, durationMs: 1 },
+      { name: "tika", ok: false, required: false, durationMs: 1 },
+    ]);
+    expect(summary.ready).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #580

> **Stacked on #589 (issue #578).** This is blocked by #578, so the PR targets `claude/issue-578`; rebase onto `main` once #589 merges. The diff shown here is only the #580 changes.

## What changed

### Build once, promote by digest (AC1, AC2)
- **[build-image.yml](.github/workflows/build-image.yml)** builds the immutable **runtime** and **migrator** images once and outputs each pinned by content digest (`image@sha256:…`). Deploy/release jobs promote the exact digest — mutable tags are never deployed.
- **Builds need no database.** The Dockerfile defaults `DATABASE_URI`/`PAYLOAD_SECRET` to build-time placeholders (`next build` imports the config but never connects), so producing the artifact requires no reachable — or real — DB.

### Approval-gated production (AC3)
- **[release.yml](.github/workflows/release.yml)**: `verify → build → staging → production`. The `production` job runs in the `production` GitHub environment; enabling **required reviewers** there makes production deployment (including migrations) pause for human approval.

### Single-instance, observable migrations (AC4, AC5)
- A dedicated **migrator** image (same commit, retains the Payload CLI + `migrations/` that the slim runner prunes) runs `pnpm migrate` **once** as a one-off container in **[promote.yml](.github/workflows/promote.yml)** — never in every replica (the entrypoint runs no migrations). The migrate step runs **before** the promote step, so a migration failure fails the job and **traffic is never switched**. Forward-fix/rollback handling is documented.

### Bounded liveness & readiness (AC6, AC7)
- **`GET /api/health/live`** — process-only, no dependency calls (so a dep outage never kills a healthy process).
- **`GET /api/health/ready`** — time-bounded MongoDB (mongoose ping) + Apache Tika (HTTP, skipped when `TIKA_ENABLED=0`) checks; `200`/`503`.
- Wired into the Docker `HEALTHCHECK` (liveness) and the Dokku **[app.json](app.json)** `startup`/`liveness`/`readiness` probes, and used as the post-deploy readiness gate in `promote.yml`. The timeout races the dependency call so a hung driver can't outlast the bound.

### Rollback & restore, rehearsed (AC8)
- Runbooks: **[release-pipeline.md](docs/deployment/release-pipeline.md)** and **[rollback-and-restore.md](docs/deployment/rollback-and-restore.md)**. Image-by-digest rollback and `mongodump`/`mongorestore` procedures were **rehearsed locally** (results recorded in the runbook).

## Verification (run locally)
- Full integration suite **245/245** passing (incl. new `health.int.spec.ts`); `tsc --noEmit` clean; lint clean; all workflow YAML + `app.json` parse.
- **Migrator image built and run end-to-end** against a fresh `mongo:7` — all three migrations applied once, cleanly.
- DB restore rehearsal: seed → `mongodump` → drop → `mongorestore --drop` recovered the document exactly; image-by-digest run confirmed.

## Notes / follow-ups
- Requires repo config: `staging`/`production` environments (required reviewers on `production`), plus `STAGING_DATABASE_URI`/`STAGING_PAYLOAD_SECRET` secrets. Documented in the runbook.
- The migrate step and readiness gate assume the runner can reach the target DB/URL; the runbook gives the `dokku run` alternative for network-isolated environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)