### PR TITLE
Fix deploy: reassemble image refs from digests (secret-scrubbed outputs)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,16 +23,18 @@ on:
         required: false
         type: string
         default: linux/arm64
+    # Only digests are exported (sha256:…). The full image reference is NOT an
+    # output: the image name contains a value matching a repository secret, and
+    # GitHub empties any output containing a secret when it crosses a job /
+    # reusable-workflow boundary. Callers reassemble `<image_name>@<digest>`
+    # from a plain image-name input plus these digests.
     outputs:
-      runtime_image:
-        description: "Immutable runtime image reference pinned by digest"
-        value: ${{ jobs.build.outputs.runtime_image }}
-      migrator_image:
-        description: "Immutable migrator image reference pinned by digest"
-        value: ${{ jobs.build.outputs.migrator_image }}
       runtime_digest:
-        description: "Runtime image digest"
+        description: "Runtime image digest (sha256:…)"
         value: ${{ jobs.build.outputs.runtime_digest }}
+      migrator_digest:
+        description: "Migrator image digest (sha256:…)"
+        value: ${{ jobs.build.outputs.migrator_digest }}
     secrets:
       DOCKER_HUB_USERNAME:
         required: true
@@ -56,9 +58,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      runtime_image: ${{ steps.refs.outputs.runtime_image }}
-      migrator_image: ${{ steps.refs.outputs.migrator_image }}
       runtime_digest: ${{ steps.build_runtime.outputs.digest }}
+      migrator_digest: ${{ steps.build_migrator.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -110,13 +111,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: "${{ inputs.image_name }}-migrator:${{ github.sha }}"
-
-      # Pin both images by digest so downstream jobs promote the exact bytes.
-      - name: Compute immutable image references
-        id: refs
-        run: |
-          echo "runtime_image=${{ inputs.image_name }}@${{ steps.build_runtime.outputs.digest }}" >> "$GITHUB_OUTPUT"
-          echo "migrator_image=${{ inputs.image_name }}-migrator@${{ steps.build_migrator.outputs.digest }}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,8 +43,9 @@ jobs:
       app_name: promisetracker-v2
       dokku_remote_url: "ssh://azureuser@ui-1.dev.codeforafrica.org"
       app_url: "https://promisetracker-v2.dev.codeforafrica.org"
-      runtime_image: ${{ needs.build.outputs.runtime_image }}
-      migrator_image: ${{ needs.build.outputs.migrator_image }}
+      image_name: "codeforafrica/promisetracker-v2"
+      runtime_digest: ${{ needs.build.outputs.runtime_digest }}
+      migrator_digest: ${{ needs.build.outputs.migrator_digest }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,10 +25,20 @@ on:
       app_url:
         required: true
         type: string
-      runtime_image:
+      # The image reference is assembled here from a plain image name plus the
+      # build digests. It is intentionally NOT passed pre-assembled: the org's
+      # image name contains a value that matches a repository secret, and
+      # GitHub empties any job/workflow output that contains a secret when it
+      # crosses a job or reusable-workflow boundary — which previously made the
+      # promoted reference arrive empty ("docker: invalid reference format").
+      # Digests (sha256:…) contain no secret and propagate cleanly.
+      image_name:
         required: true
         type: string
-      migrator_image:
+      runtime_digest:
+        required: true
+        type: string
+      migrator_digest:
         required: true
         type: string
       run_migrations:
@@ -80,7 +90,7 @@ jobs:
             -e DATABASE_URI \
             -e PAYLOAD_SECRET \
             -e TIKA_ENABLED=0 \
-            "${{ inputs.migrator_image }}"
+            "${{ inputs.image_name }}-migrator@${{ inputs.migrator_digest }}"
 
       # Promote the EXACT runtime image (by digest) that was built and verified.
       - name: Deploy runtime image to Dokku
@@ -88,7 +98,7 @@ jobs:
         with:
           git_remote_url: ${{ inputs.dokku_remote_url }}/${{ inputs.app_name }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          deploy_docker_image: ${{ inputs.runtime_image }}
+          deploy_docker_image: ${{ inputs.image_name }}@${{ inputs.runtime_digest }}
 
       # Bounded post-deploy readiness gate: fail the release if the new instance
       # does not become ready (Mongo + Tika) within the window.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,9 @@ jobs:
       app_name: promisetracker-v2-staging
       dokku_remote_url: "ssh://azureuser@ui-1.dev.codeforafrica.org"
       app_url: "https://promisetracker-v2.staging.codeforafrica.org"
-      runtime_image: ${{ needs.build.outputs.runtime_image }}
-      migrator_image: ${{ needs.build.outputs.migrator_image }}
+      image_name: "codeforafrica/promisetracker-v2"
+      runtime_digest: ${{ needs.build.outputs.runtime_digest }}
+      migrator_digest: ${{ needs.build.outputs.migrator_digest }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -78,8 +79,9 @@ jobs:
       app_name: promisetracker-v2
       dokku_remote_url: "ssh://azureuser@ui-1.dev.codeforafrica.org"
       app_url: "https://promisetracker.codeforafrica.org"
-      runtime_image: ${{ needs.build.outputs.runtime_image }}
-      migrator_image: ${{ needs.build.outputs.migrator_image }}
+      image_name: "codeforafrica/promisetracker-v2"
+      runtime_digest: ${{ needs.build.outputs.runtime_digest }}
+      migrator_digest: ${{ needs.build.outputs.migrator_digest }}
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
## Problem

The dev deploy on merge to `main` failed at the migrate step:

```
Run docker run --rm \
docker: invalid reference format
Error: Process completed with exit code 125.
```

In the failed run, the `promote` job received **empty** `runtime_image` and `migrator_image`, even though the `build` job produced correct values (`…@sha256:9bec87…` was written to `$GITHUB_OUTPUT`).

## Root cause

The image name contains a value that matches a repository secret (visible in logs as `codeforafrica/***-v2`). **GitHub empties any job or reusable-workflow output whose value contains a secret** when it crosses a job/workflow boundary. So the pre-assembled `<image>@<digest>` outputs were scrubbed to empty strings by the time they reached `promote.yml` → `docker run … ""` → *invalid reference format*.

## Fix

Keep secrets out of propagated outputs by passing only **digests** (`sha256:…`, secret-free) across the boundary and assembling the reference where it's used:

- **build-image.yml** now outputs `runtime_digest` and `migrator_digest` (dropped the secret-tainted `runtime_image`/`migrator_image` outputs and the ref-building step).
- **promote.yml** takes a plain `image_name` input plus the two digests and builds `${image_name}@${runtime_digest}` (deploy) and `${image_name}-migrator@${migrator_digest}` (migrate) internally.
- **deploy-dev.yml** and **release.yml** pass `image_name` + `runtime_digest` + `migrator_digest`.

Immutability is preserved — deploys still pin the exact digest built and verified.

## Verification
- No remaining `runtime_image`/`migrator_image` references in `.github/workflows/`.
- All four workflow files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)