### PR TITLE
Fix deploy: build migrator image for the CI runner architecture

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -99,14 +99,18 @@ jobs:
             "sentry_project=${{ secrets.SENTRY_PROJECT }}"
           tags: "${{ inputs.image_name }}:${{ github.sha }}"
 
-      # Build the migrator image from the same commit for the release migrate step.
+      # Build the migrator image from the same commit for the release migrate
+      # step. Unlike the runtime image (deployed to the arm64 Dokku host), the
+      # migrator is only ever executed via `docker run` on the amd64 GitHub
+      # runner, so it must be built for the runner's architecture — building it
+      # arm64-only produced "no matching manifest for linux/amd64" at run time.
       - name: Build and push migrator image
         id: build_migrator
         uses: docker/build-push-action@v6
         with:
           context: .
           target: migrator
-          platforms: ${{ inputs.platforms }}
+          platforms: linux/amd64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem

After the digest fix (#596), the dev deploy got past reference assembly but the migrate step now fails:

```
docker run --rm … "codeforafrica/promisetracker-v2-migrator@sha256:144e…"
docker: no matching manifest for linux/amd64 in the manifest list entries
Error: Process completed with exit code 125.
```

## Root cause

`build-image.yml` builds **both** images for `inputs.platforms` (default `linux/arm64`, for the Dokku host). But the migrator image isn't deployed to Dokku — it's executed with `docker run` on the **amd64 GitHub runner** during the migrate step. An arm64-only image has no amd64 manifest, so `docker run` on the runner can't pull/run it.

## Fix

Build the **migrator** image for `linux/amd64` (the runner's architecture). The **runtime** image is unchanged — still `inputs.platforms` (arm64) for the Dokku host. The migrator is a throwaway one-off that only ever runs on the CI runner, so single-arch amd64 is correct and fastest (native, no emulation).

## Verification
- `build-image.yml` parses as valid YAML.
- Reference assembly from #596 is unchanged; this only changes the migrator build platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)