### PR TITLE
ci: build images on native runners via docker bake (~44m → ~10m)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,6 +7,12 @@ name: Build image
 #
 # Production artifact creation does not require a reachable database: the
 # Dockerfile defaults DATABASE_URI/PAYLOAD_SECRET to build-time placeholders.
+#
+# PERFORMANCE: each target is built on a NATIVE runner via docker/bake-action —
+# runtime on an arm64 runner (arm64 Dokku host) and migrator on an amd64 runner
+# (it is only ever `docker run` on the amd64 GitHub runner during a release).
+# This replaces the previous single-runner QEMU-emulated arm64 build, which
+# took ~45 min; native builds run in a fraction of that and in parallel.
 on:
   workflow_call:
     inputs:
@@ -19,10 +25,6 @@ on:
       sentry_environment:
         required: true
         type: string
-      platforms:
-        required: false
-        type: string
-        default: linux/arm64
     # Only digests are exported (sha256:…). The full image reference is NOT an
     # output: the image name contains a value matching a repository secret, and
     # GitHub empties any output containing a secret when it crosses a job /
@@ -31,10 +33,10 @@ on:
     outputs:
       runtime_digest:
         description: "Runtime image digest (sha256:…)"
-        value: ${{ jobs.build.outputs.runtime_digest }}
+        value: ${{ jobs.runtime.outputs.digest }}
       migrator_digest:
         description: "Migrator image digest (sha256:…)"
-        value: ${{ jobs.build.outputs.migrator_digest }}
+        value: ${{ jobs.migrator.outputs.digest }}
     secrets:
       DOCKER_HUB_USERNAME:
         required: true
@@ -55,19 +57,17 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  # Runtime image, built natively on arm64 (no QEMU) — this is the image
+  # deployed to the arm64 Dokku host.
+  runtime:
+    runs-on: ubuntu-24.04-arm
     outputs:
-      runtime_digest: ${{ steps.build_runtime.outputs.digest }}
-      migrator_digest: ${{ steps.build_migrator.outputs.digest }}
+      digest: ${{ steps.digest.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -78,48 +78,96 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      # Build the runtime image once. No real/reachable database is required.
       - name: Build and push runtime image
-        id: build_runtime
-        uses: docker/build-push-action@v7
+        id: bake
+        uses: docker/bake-action@v7
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          TAG: ${{ github.sha }}
+          NEXT_PUBLIC_APP_URL: ${{ inputs.next_public_app_url }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: ${{ inputs.sentry_environment }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
-          context: .
-          target: runner
-          platforms: ${{ inputs.platforms }}
+          files: docker-bake.hcl
+          targets: runtime
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            NEXT_PUBLIC_APP_URL=${{ inputs.next_public_app_url }}
-            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-            SENTRY_ENVIRONMENT=${{ inputs.sentry_environment }}
-          secrets: |
-            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
-            "sentry_org=${{ secrets.SENTRY_ORG }}"
-            "sentry_project=${{ secrets.SENTRY_PROJECT }}"
-          tags: "${{ inputs.image_name }}:${{ github.sha }}"
+          set: |
+            *.cache-from=type=gha,scope=runtime
+            *.cache-to=type=gha,mode=max,scope=runtime
 
-      # Build the migrator image from the same commit for the release migrate
-      # step. Unlike the runtime image (deployed to the arm64 Dokku host), the
-      # migrator is only ever executed via `docker run` on the amd64 GitHub
-      # runner, so it must be built for the runner's architecture — building it
-      # arm64-only produced "no matching manifest for linux/amd64" at run time.
-      - name: Build and push migrator image
-        id: build_migrator
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: migrator
-          platforms: linux/amd64
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: "${{ inputs.image_name }}-migrator:${{ github.sha }}"
+      # Export the pushed manifest digest so callers can pin by digest.
+      - name: Extract digest
+        id: digest
+        run: |
+          digest="$(echo '${{ steps.bake.outputs.metadata }}' \
+            | jq -r '.runtime."containerimage.digest"')"
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "::error::Could not read runtime image digest from bake metadata"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Summarize
         run: |
           {
-            echo "### Built images"
-            echo "- runtime: \`${{ inputs.image_name }}@${{ steps.build_runtime.outputs.digest }}\`"
-            echo "- migrator: \`${{ inputs.image_name }}-migrator@${{ steps.build_migrator.outputs.digest }}\`"
+            echo "### Built runtime image"
+            echo "- runtime: \`${{ inputs.image_name }}@${{ steps.digest.outputs.digest }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Migrator image, built natively on amd64. Unlike the runtime image (deployed
+  # to the arm64 Dokku host), the migrator is only ever executed via `docker
+  # run` on the amd64 GitHub runner during the release migrate step, so it must
+  # be built for the runner's architecture.
+  migrator:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push migrator image
+        id: bake
+        uses: docker/bake-action@v7
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          TAG: ${{ github.sha }}
+        with:
+          files: docker-bake.hcl
+          targets: migrator
+          push: true
+          set: |
+            *.cache-from=type=gha,scope=migrator
+            *.cache-to=type=gha,mode=max,scope=migrator
+
+      - name: Extract digest
+        id: digest
+        run: |
+          digest="$(echo '${{ steps.bake.outputs.metadata }}' \
+            | jq -r '.migrator."containerimage.digest"')"
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "::error::Could not read migrator image digest from bake metadata"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize
+        run: |
+          {
+            echo "### Built migrator image"
+            echo "- migrator: \`${{ inputs.image_name }}-migrator@${{ steps.digest.outputs.digest }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,65 @@
+# Docker Bake definition for the Promise Tracker images.
+#
+# Single source of truth for how the immutable runtime and migrator images are
+# built. Used by .github/workflows/build-image.yml (CI) and reproducible
+# locally with `docker buildx bake`.
+#
+# The two targets are built on separate NATIVE runners rather than via QEMU
+# emulation (see the workflow), which is what makes CI fast:
+#   - runtime  -> linux/arm64 (deployed to the arm64 Dokku host)
+#   - migrator -> linux/amd64 (only ever `docker run` on the amd64 GH runner)
+
+variable "IMAGE_NAME" {
+  default = "codeforafrica/promisetracker-v2"
+}
+
+# Image tag (usually the git SHA). "local" is the dev default.
+variable "TAG" {
+  default = "local"
+}
+
+# Public, build-time-inlined Next.js config. Safe to appear in logs.
+variable "NEXT_PUBLIC_APP_URL" {
+  default = "http://localhost:3000"
+}
+
+variable "NEXT_PUBLIC_SENTRY_DSN" {
+  default = ""
+}
+
+variable "SENTRY_ENVIRONMENT" {
+  default = "development"
+}
+
+# `docker buildx bake` with no target builds both.
+group "default" {
+  targets = ["runtime", "migrator"]
+}
+
+# Production runtime image (slim standalone Next.js server + Tika).
+target "runtime" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "runner"
+  tags       = ["${IMAGE_NAME}:${TAG}"]
+  args = {
+    NEXT_PUBLIC_APP_URL    = "${NEXT_PUBLIC_APP_URL}"
+    NEXT_PUBLIC_SENTRY_DSN = "${NEXT_PUBLIC_SENTRY_DSN}"
+    SENTRY_ENVIRONMENT     = "${SENTRY_ENVIRONMENT}"
+  }
+  # Sentry source-map upload credentials — never inlined into the image layers.
+  secret = [
+    "type=env,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN",
+    "type=env,id=sentry_org,env=SENTRY_ORG",
+    "type=env,id=sentry_project,env=SENTRY_PROJECT",
+  ]
+}
+
+# Migrator image: retains the Payload CLI + migrations/ to run `payload migrate`
+# exactly once during a release. No app build, no Tika/JRE — fast to build.
+target "migrator" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "migrator"
+  tags       = ["${IMAGE_NAME}-migrator:${TAG}"]
+}


### PR DESCRIPTION
## Problem

Merging to `main` takes **~49 min**, almost entirely in the image `build` job. Per run [#598](https://github.com/CodeForAfrica/PromiseTracker/actions/runs/29986147793):

| Job | Duration |
|-----|----------|
| verify (lint/types/tests) | ~3 min |
| **build** | **~44 min** |
| deploy | ~2 min |

The build compiled `linux/arm64` under **QEMU emulation** on an amd64 runner. `next build` + JRE/Tika download + `apk`/`pnpm` under emulation runs ~5–10× slower than native.

## Fix

Build each target on a **native runner** via `docker/bake-action`:

- `runtime` → `ubuntu-24.04-arm` (native arm64, **no QEMU**) — the image deployed to the arm64 Dokku host
- `migrator` → `ubuntu-latest` (native amd64, as before) — only ever `docker run` on the amd64 GH runner during a release

Both build **in parallel**.

## Changes

- **`docker-bake.hcl`** (new) — single source of truth for the `runtime` and `migrator` build config.
- **`.github/workflows/build-image.yml`** — internals rewritten to bake on native runners; digests read from bake metadata with a hard-fail guard.

## Blast radius

The reusable workflow keeps the **same `workflow_call` interface** — `runtime_digest` / `migrator_digest` outputs and the same secrets. So `deploy-dev.yml`, `release.yml`, and the digest-pinned `promote.yml` are **unchanged**. Only the unused `platforms` input was dropped (no caller passed it).

No base-image split (the other half of the `ui` setup) — that shares layers across many apps in a monorepo; this is a single app, so GHA cache (scoped per target) already covers it.

## Expected result

Build ~44 min → **~8–12 min**; total merge-to-main ~**12–15 min**.

## Notes

- Native arm64 runners are free here because this repo is **public**.
- First real validation is the initial merge-to-main run — the extract step hard-fails loudly if `docker/bake-action`'s metadata digest ever comes back empty, rather than deploying a bad ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)