### PR TITLE
ci: fix digest extraction breaking on bake metadata JSON

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -99,11 +99,14 @@ jobs:
             *.cache-to=type=gha,mode=max,scope=runtime
 
       # Export the pushed manifest digest so callers can pin by digest.
+      # The metadata is passed via env (never inlined into the script body) so
+      # its JSON braces/quotes cannot break shell parsing.
       - name: Extract digest
         id: digest
+        env:
+          METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          digest="$(echo '${{ steps.bake.outputs.metadata }}' \
-            | jq -r '.runtime."containerimage.digest"')"
+          digest="$(jq -r '.runtime."containerimage.digest"' <<< "$METADATA")"
           if [ -z "$digest" ] || [ "$digest" = "null" ]; then
             echo "::error::Could not read runtime image digest from bake metadata"
             exit 1
@@ -156,9 +159,10 @@ jobs:
 
       - name: Extract digest
         id: digest
+        env:
+          METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          digest="$(echo '${{ steps.bake.outputs.metadata }}' \
-            | jq -r '.migrator."containerimage.digest"')"
+          digest="$(jq -r '.migrator."containerimage.digest"' <<< "$METADATA")"
           if [ -z "$digest" ] || [ "$digest" = "null" ]; then
             echo "::error::Could not read migrator image digest from bake metadata"
             exit 1


### PR DESCRIPTION
## Problem

The native-runner build (#600) merged, but the first `deploy-dev` run on `main` failed in the digest extraction step:

```
/home/runner/work/_temp/....sh: line 84: syntax error near unexpected token `('
Error: Process completed with exit code 2.
```

The step inlined `${{ steps.bake.outputs.metadata }}` directly into the `run:` script body. That metadata is a multi-line JSON blob, and its braces/quotes/parens were parsed as shell syntax.

## Fix

Pass the metadata through an environment variable and read it with a here-string, so its contents are never interpreted by the shell:

```yaml
env:
  METADATA: ${{ steps.bake.outputs.metadata }}
run: |
  digest="$(jq -r '.runtime."containerimage.digest"' <<< "$METADATA")"
```

Applied to both the `runtime` and `migrator` extract steps. The hard-fail guard on an empty/`null` digest is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)