### PR TITLE
perf: pull Tika jar from Maven Central (~8.5m → ~20s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,10 @@ CMD ["pnpm", "migrate"]
 # Production image, copy all the files and run next
 FROM base AS runner
 ARG TIKA_VERSION=3.2.3
+# SHA-256 of tika-server-standard-${TIKA_VERSION}.jar. MUST be updated together
+# with TIKA_VERSION. To get it for a new version:
+#   curl -sSL https://repo1.maven.org/maven2/org/apache/tika/tika-server-standard/<v>/tika-server-standard-<v>.jar | sha256sum
+ARG TIKA_SHA256=c00898065af088925ba4b65856db66e6140e4c750d28219b61b96885885e7593
 WORKDIR /app
 
 ENV NODE_ENV=production \
@@ -76,8 +80,14 @@ RUN apk add --no-cache openjdk17-jre-headless curl
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
+# Pull the Tika server jar from Maven Central rather than archive.apache.org:
+# the archive host is throttled to ~200KB/s and this 66MB download took ~8.5min
+# on cold-cache builds; Maven Central is a fast CDN (~20s) and keeps every
+# version permanently. The checksum is verified so a corrupt/tampered download
+# fails the build.
 RUN mkdir -p /opt/tika \
-  && curl -fsSL "https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" -o "${TIKA_SERVER_JAR}" \
+  && curl -fsSL "https://repo1.maven.org/maven2/org/apache/tika/tika-server-standard/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" -o "${TIKA_SERVER_JAR}" \
+  && echo "${TIKA_SHA256}  ${TIKA_SERVER_JAR}" | sha256sum -c - \
   && chmod 644 "${TIKA_SERVER_JAR}"
 
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Problem

After moving builds to native runners, the runtime build was ~11.5 min. Layer timings from the first native build showed one line dominating:

| Layer | Time |
|-------|------|
| **Tika jar download from `archive.apache.org`** | **502.7s (8.5 min)** |
| `next build` | 179s (3.0 min) |
| export/push | 171s (2.8 min) |
| everything else | ~1 min |

`archive.apache.org` deliberately throttles downloads (~200 KB/s), and the Tika server jar is ~66 MB.

## Fix

Pull the **identical artifact** from **Maven Central** (`repo1.maven.org`), a fast global CDN that retains every version permanently.

Measured, same file (66,227,320 bytes):

| Source | Result |
|--------|--------|
| archive.apache.org | 13 MB in 60s, then timed out (~200 KB/s) |
| Maven Central | full 66 MB in ~20s (~3.4 MB/s) |

Also **pin and verify the SHA-256** of the jar so a corrupt or tampered download fails the build. Authenticity of the pinned hash was cross-checked against Maven Central's published `.sha1`. `TIKA_SHA256` must be bumped alongside `TIKA_VERSION`; the command to fetch the new hash is documented inline.

## Expected result

Runtime build ~11.5 min → **~4–5 min** (dominated now by `next build` + push, which run at native speed).

## Notes

- This is independent of #601 (the digest-extraction fix), which should merge first to unbreak `deploy-dev` on `main`.
- A further structural option exists if ever needed — a pre-baked runner base image with JRE + Tika (the pattern the `ui` repo uses) — but with this change the download is no longer a meaningful cost, so it isn't worth the added complexity for a single app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)